### PR TITLE
Adds --saa.alert-expiration-time as config parameter

### DIFF
--- a/config/Config.md
+++ b/config/Config.md
@@ -144,6 +144,17 @@
 
 ## ScaleAlertAggregator
 
+### Alert Expiration Time
+
+|         |                                                                                                                                                              |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| name    | alert-expiration-time                                                                                                                                        |
+| usage   | Defines after which time an alert will be pruned if he did not get updated again by the ScaleAlertEmitter, assuming that the alert is not relevant any more. |
+| type    | Duration                                                                                                                                                     |
+| default | 10m                                                                                                                                                          |
+| flag    | --saa.alert-expiration-time                                                                                                                                  |
+| env     | SK_SAA_ALERT_EXPIRATION_TIME                                                                                                                                 |
+
 ### No Alert Damping
 
 |         |                                                                                          |
@@ -190,14 +201,14 @@
 
 ### Evaluation Period Factor
 
-|         |                                                                                                                                  |
-| ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| name    | eval-period-factor                                                                                                               |
-| usage   | EvaluationPeriodFactor is used to calculate the evaluation period (evaluationPeriod = evaluationCycle * evaluationPeriodFactor). |
-| type    | uint                                                                                                                             |
-| default | 10                                                                                                                               |
-| flag    | --saa.eval-period-factor                                                                                                         |
-| env     | SK_SAA_EVAL_PERIOD_FACTOR                                                                                                        |
+|         |                                                                                                                                   |
+| ------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| name    | eval-period-factor                                                                                                                |
+| usage   | EvaluationPeriodFactor is used to calculate the evaluation period (evaluationPeriod = evaluationCycle \* evaluationPeriodFactor). |
+| type    | uint                                                                                                                              |
+| default | 10                                                                                                                                |
+| flag    | --saa.eval-period-factor                                                                                                          |
+| env     | SK_SAA_EVAL_PERIOD_FACTOR                                                                                                         |
 
 ### Cleanup Cycle
 

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type ScaleAlertAggregator struct {
 	EvaluationCycle        time.Duration `json:"evaluation_cycle,omitempty"`
 	EvaluationPeriodFactor uint          `json:"evaluation_period_factor,omitempty"`
 	CleanupCycle           time.Duration `json:"cleanup_cycle,omitempty"`
+	AlertExpirationTime    time.Duration `json:"alert_expiration_time,omitempty"`
 }
 
 // Alert represents an alert defined by its name and weight
@@ -84,6 +85,7 @@ func NewDefaultConfig() Config {
 			UpScaleThreshold:       10,
 			DownScaleThreshold:     -10,
 			ScaleAlerts:            make([]Alert, 0),
+			AlertExpirationTime:    time.Minute * 10,
 		},
 		CapacityPlanner: CapacityPlanner{
 			DownScaleCooldownPeriod: time.Second * 80,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,6 +17,7 @@ func Test_NewDefaultConfig(t *testing.T) {
 	assert.Equal(t, time.Second*1, config.ScaleAlertAggregator.EvaluationCycle)
 	assert.Equal(t, uint(10), config.ScaleAlertAggregator.EvaluationPeriodFactor)
 	assert.Equal(t, time.Second*60, config.ScaleAlertAggregator.CleanupCycle)
+	assert.Equal(t, time.Minute*10, config.ScaleAlertAggregator.AlertExpirationTime)
 	assert.NotNil(t, config.ScaleAlertAggregator.ScaleAlerts)
 	assert.Empty(t, config.ScaleAlertAggregator.ScaleAlerts)
 }

--- a/config/entries.go
+++ b/config/entries.go
@@ -105,6 +105,14 @@ var loggingNoColor = configEntry{
 }
 
 // ###################### Context: ScaleAlertAggregator ###################################
+var saaAlertExpirationTime = configEntry{
+	name:         "saa.alert-expiration-time",
+	bindEnv:      true,
+	bindFlag:     true,
+	defaultValue: time.Minute * 10,
+	usage:        "Defines after which time an alert will be pruned if he did not get updated again by the ScaleAlertEmitter, assuming that the alert is not relevant any more.",
+}
+
 var saaNoAlertDamping = configEntry{
 	name:         "saa.no-alert-damping",
 	bindEnv:      true,
@@ -180,4 +188,5 @@ var configEntries = []configEntry{
 	saaEvalPeriodFactor,
 	saaCleanupCylce,
 	saaScaleAlerts,
+	saaAlertExpirationTime,
 }

--- a/config/fillCfg.go
+++ b/config/fillCfg.go
@@ -58,6 +58,7 @@ func (cfg *Config) fillCfgValues() error {
 		return err
 	}
 	cfg.ScaleAlertAggregator.ScaleAlerts = alerts
+	cfg.ScaleAlertAggregator.AlertExpirationTime = cfg.viper.GetDuration(saaAlertExpirationTime.name)
 
 	return nil
 }

--- a/config/fillCfg_test.go
+++ b/config/fillCfg_test.go
@@ -30,6 +30,7 @@ func Test_FillCfg_Flags(t *testing.T) {
 		"--saa.cleanup-cycle=104s",
 		"--saa.eval-period-factor=105",
 		"--saa.scale-alerts=alert 1:1.2:This is an upscaling alert",
+		"--saa.alert-expiration-time=5m",
 	}
 
 	err := cfg.ReadConfig(args)
@@ -55,6 +56,7 @@ func Test_FillCfg_Flags(t *testing.T) {
 	assert.Equal(t, "alert 1", cfg.ScaleAlertAggregator.ScaleAlerts[0].Name)
 	assert.Equal(t, float32(1.2), cfg.ScaleAlertAggregator.ScaleAlerts[0].Weight)
 	assert.Equal(t, "This is an upscaling alert", cfg.ScaleAlertAggregator.ScaleAlerts[0].Description)
+	assert.Equal(t, time.Minute*5, cfg.ScaleAlertAggregator.AlertExpirationTime)
 }
 
 func Test_AlertMapToAlerts(t *testing.T) {

--- a/examples/config/full.yaml
+++ b/examples/config/full.yaml
@@ -16,6 +16,7 @@ saa:
   eval-cycle: 1s
   eval-period-factor: 10
   cleanup-cycle: 60s
+  alert-expiration-time: 5m
   scale-alerts:
     - name: "AlertA"
       weight: 1.5

--- a/scaleAlertAggregator/metrics_test.go
+++ b/scaleAlertAggregator/metrics_test.go
@@ -2,6 +2,7 @@ package scaleAlertAggregator
 
 import (
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -69,7 +70,7 @@ func Test_UpdateAlertMetrics(t *testing.T) {
 		mocks.alerts.EXPECT().WithLabelValues("neutral").Return(gaugeNeutral),
 	)
 
-	scap := NewScaleAlertPool()
+	scap := NewScaleAlertPool(time.Second * 60)
 	scap.entries[1] = ScaleAlertPoolEntry{weight: 1}
 	scap.entries[2] = ScaleAlertPoolEntry{weight: -1}
 	scap.entries[3] = ScaleAlertPoolEntry{weight: -100}

--- a/scaleAlertAggregator/scaleAlertAggregator.go
+++ b/scaleAlertAggregator/scaleAlertAggregator.go
@@ -87,6 +87,10 @@ type Config struct {
 	EvaluationCycle        time.Duration
 	EvaluationPeriodFactor uint
 	CleanupCycle           time.Duration
+
+	// AlertExpirationTime defines after which time an alert will be pruned if he did not
+	// get updated again by the ScaleAlertEmitter, assuming that the alert is not relevant any more.
+	AlertExpirationTime time.Duration
 }
 
 // NewDefaultConfig creates an empty default configuration
@@ -99,6 +103,7 @@ func NewDefaultConfig() Config {
 		EvaluationCycle:        time.Second * 1,
 		EvaluationPeriodFactor: 10,
 		CleanupCycle:           time.Second * 60,
+		AlertExpirationTime:    time.Minute * 10,
 	}
 }
 
@@ -108,7 +113,7 @@ func (cfg Config) New(emitters []ScaleAlertEmitter, metrics Metrics) *ScaleAlert
 		logger:                 cfg.Logger,
 		emitters:               emitters,
 		stopChan:               make(chan struct{}, 1),
-		scaleAlertPool:         NewScaleAlertPool(),
+		scaleAlertPool:         NewScaleAlertPool(cfg.AlertExpirationTime),
 		evaluationCycle:        cfg.EvaluationCycle,
 		evaluationPeriodFactor: cfg.EvaluationPeriodFactor,
 		cleanupCycle:           cfg.CleanupCycle,

--- a/scaleAlertAggregator/scaleAlertPool.go
+++ b/scaleAlertAggregator/scaleAlertPool.go
@@ -41,9 +41,11 @@ type ScaleAlertPoolEntry struct {
 }
 
 // NewScaleAlertPool creates a new empty pool
-func NewScaleAlertPool() ScaleAlertPool {
+// The parameter alertExpirationTime defines after which time an alert will be pruned if he did not
+// get updated again by the ScaleAlertEmitter, assuming that the alert is not relevant any more.
+func NewScaleAlertPool(alertExpirationTime time.Duration) ScaleAlertPool {
 	return ScaleAlertPool{
-		ttl:     time.Minute * 60,
+		ttl:     alertExpirationTime,
 		entries: make(map[uint32]ScaleAlertPoolEntry),
 	}
 }

--- a/scaleAlertAggregator/scaleAlertPool_test.go
+++ b/scaleAlertAggregator/scaleAlertPool_test.go
@@ -10,12 +10,12 @@ import (
 )
 
 func TestNewPool(t *testing.T) {
-	scap := NewScaleAlertPool()
+	scap := NewScaleAlertPool(time.Second * 60)
 	assert.NotNil(t, scap.entries)
 }
 
 func Test_Cleanup(t *testing.T) {
-	scap := NewScaleAlertPool()
+	scap := NewScaleAlertPool(time.Second * 60)
 
 	now := time.Now()
 	expired := now.Add(time.Minute * -1)
@@ -36,7 +36,7 @@ func Test_Cleanup(t *testing.T) {
 }
 
 func Test_Update(t *testing.T) {
-	scap := NewScaleAlertPool()
+	scap := NewScaleAlertPool(time.Second * 60)
 
 	var scaleAlerts []ScaleAlert
 
@@ -77,7 +77,7 @@ func Test_Update(t *testing.T) {
 }
 
 func Test_Sync(t *testing.T) {
-	scap := NewScaleAlertPool()
+	scap := NewScaleAlertPool(time.Second * 60)
 
 	weightMap := make(ScaleAlertWeightMap, 0)
 	weightMap["Alert1"] = 1
@@ -122,7 +122,7 @@ func Test_Sync(t *testing.T) {
 }
 
 func Test_Iterate(t *testing.T) {
-	scap := NewScaleAlertPool()
+	scap := NewScaleAlertPool(time.Second * 60)
 
 	var scaleAlerts []ScaleAlert
 


### PR DESCRIPTION
With this MR the expiration time for scale alerts that get not further updated by the ScaleAlertEmitter is configurable.