### PR TITLE
Respect min/max count after restart

### DIFF
--- a/examples/multi-group.nomad
+++ b/examples/multi-group.nomad
@@ -10,7 +10,7 @@ job "fail-service" {
       
 
   group "fail-service-grp-A" {
-    count = 1
+    count = 2
     task "fail-service" {
       driver = "docker"
       config {

--- a/scaler/scale.go
+++ b/scaler/scale.go
@@ -153,6 +153,7 @@ func (s *Scaler) scale(desiredCount uint, currentCount uint, dryRun bool) scaleR
 	s.metrics.plannedButSkippedScalingOpen.WithLabelValues(scaleTypeStr).Set(0)
 
 	// Set the new job count
+	s.desiredScale = &newCount
 	err = s.scalingTarget.SetJobCount(s.job.jobName, newCount)
 	if err != nil {
 		return scaleResult{

--- a/scaler/scale_test.go
+++ b/scaler/scale_test.go
@@ -56,6 +56,7 @@ func TestScale_Up(t *testing.T) {
 	scaTgt.EXPECT().IsJobDead(jobname).Return(false, nil)
 	scaTgt.EXPECT().SetJobCount(jobname, uint(2)).Return(nil)
 	result := scaler.scale(2, 0, false)
+	assert.Equal(t, uint(2), *scaler.desiredScale)
 	assert.NotEqual(t, scaleFailed, result.state)
 
 	// scale up - max hit
@@ -65,6 +66,7 @@ func TestScale_Up(t *testing.T) {
 	scaTgt.EXPECT().IsJobDead(jobname).Return(false, nil)
 	scaTgt.EXPECT().SetJobCount(jobname, uint(5)).Return(nil)
 	result = scaler.scale(6, 0, false)
+	assert.Equal(t, uint(5), *scaler.desiredScale)
 	assert.NotEqual(t, scaleFailed, result.state)
 }
 
@@ -89,6 +91,7 @@ func TestScale_Down(t *testing.T) {
 	scaTgt.EXPECT().IsJobDead(jobname).Return(false, nil)
 	scaTgt.EXPECT().SetJobCount(jobname, uint(1)).Return(nil)
 	result := scaler.scale(1, 4, false)
+	assert.Equal(t, uint(1), *scaler.desiredScale)
 	assert.NotEqual(t, scaleFailed, result.state)
 
 	// scale up - min hit
@@ -98,6 +101,7 @@ func TestScale_Down(t *testing.T) {
 	scaTgt.EXPECT().IsJobDead(jobname).Return(false, nil)
 	scaTgt.EXPECT().SetJobCount(jobname, uint(1)).Return(nil)
 	result = scaler.scale(0, 2, false)
+	assert.Equal(t, uint(1), *scaler.desiredScale)
 	assert.NotEqual(t, scaleFailed, result.state)
 }
 
@@ -117,6 +121,7 @@ func TestScale_NoScale(t *testing.T) {
 	// scale down
 	scaTgt.EXPECT().IsJobDead(jobname).Return(false, nil)
 	result := scaler.scale(2, 2, false)
+	assert.Nil(t, scaler.desiredScale)
 	assert.NotEqual(t, scaleFailed, result.state)
 }
 

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -34,6 +34,9 @@ type Scaler struct {
 	maxOpenScalingTickets uint
 	scaleTicketChan       chan ScalingTicket
 
+	// desiredScale reflects the last successfully applied scale
+	desiredScale *uint
+
 	// channel used to signal teardown/ stop
 	stopChan chan struct{}
 
@@ -79,6 +82,7 @@ func (cfg Config) New(scalingTarget ScalingTarget, metrics Metrics) (*Scaler, er
 		maxOpenScalingTickets: cfg.MaxOpenScalingTickets,
 		scaleTicketChan:       make(chan ScalingTicket, cfg.MaxOpenScalingTickets+1),
 		metrics:               metrics,
+		desiredScale:          nil,
 	}, nil
 }
 

--- a/scaler/scalerImpl.go
+++ b/scaler/scalerImpl.go
@@ -19,7 +19,9 @@ func (s *Scaler) jobWatcher(cycle time.Duration) {
 			s.logger.Info().Msg("JobWatcher Closed.")
 			return
 		case <-jobWatcherTicker.C:
-			s.logger.Error().Msg("Check job state (not implemented yet).")
+			if err := s.ensureJobCount(); err != nil {
+				s.logger.Error().Msgf("Check job state failed: %s", err.Error())
+			}
 		}
 	}
 }

--- a/scaler/watchJob.go
+++ b/scaler/watchJob.go
@@ -1,0 +1,58 @@
+package scaler
+
+import "strconv"
+
+// countMeetsExpectations returns false in case the current count does not match the
+// expectations. This could either be the case if the current deployed amount
+// of allocations is "out of bounds" regarding the defined min/ max of the job.
+// Or if a the current count does not correlate to the desired amount of allocations
+// being deployed.
+func countMeetsExpectations(current uint, min uint, max uint, desired *uint) (asExpected bool, expectedCount uint) {
+
+	asExpected = true
+	expectedCount = current
+
+	if desired != nil {
+		expectedCount = *desired
+	}
+
+	if current != expectedCount {
+		asExpected = false
+	}
+
+	if current < min {
+		expectedCount = min
+		asExpected = false
+	}
+
+	if current > max {
+		expectedCount = max
+		asExpected = false
+	}
+
+	return asExpected, expectedCount
+}
+
+func (s *Scaler) ensureJobCount() error {
+
+	count, err := s.GetCount()
+	if err != nil {
+		return err
+	}
+
+	asExpected, expected := countMeetsExpectations(count, s.job.minCount, s.job.maxCount, s.desiredScale)
+	if !asExpected {
+		s.logger.Warn().Msgf("The job count (%d) was not as expected. Thus the job had to be rescaled to %d.", count, expected)
+		if err := s.openScalingTicket(expected, false); err != nil {
+			return err
+		}
+	} else {
+		desiredStr := "n/a"
+		if s.desiredScale != nil {
+			desiredStr = strconv.Itoa(int(*s.desiredScale))
+		}
+		s.logger.Debug().Uint("count", count).Str("desired", desiredStr).Uint("expected", expected).Msg("Count as expected, no adjustment needed.")
+	}
+
+	return nil
+}

--- a/scaler/watchJob_test.go
+++ b/scaler/watchJob_test.go
@@ -1,0 +1,117 @@
+package scaler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/thomasobenaus/sokar/test/metrics"
+	"github.com/thomasobenaus/sokar/test/scaler"
+)
+
+func TestCountMeetsExpectations(t *testing.T) {
+
+	desired := uint(1)
+	asExpected, expected := countMeetsExpectations(1, 1, 2, &desired)
+	assert.True(t, asExpected)
+	assert.Equal(t, uint(1), expected)
+
+	// min violated
+	asExpected, expected = countMeetsExpectations(0, 1, 2, &desired)
+	assert.False(t, asExpected)
+	assert.Equal(t, uint(1), expected)
+
+	// max violated
+	asExpected, expected = countMeetsExpectations(3, 1, 2, &desired)
+	assert.False(t, asExpected)
+	assert.Equal(t, uint(2), expected)
+
+	// no desired
+	asExpected, expected = countMeetsExpectations(1, 1, 2, nil)
+	assert.True(t, asExpected)
+	assert.Equal(t, uint(1), expected, "Expected to stay at current count since desired is nil.")
+
+	// desired over max
+	desired = uint(10)
+	asExpected, expected = countMeetsExpectations(3, 1, 2, &desired)
+	assert.False(t, asExpected)
+	assert.Equal(t, uint(2), expected)
+
+	// desired under min
+	desired = uint(0)
+	asExpected, expected = countMeetsExpectations(3, 1, 2, &desired)
+	assert.False(t, asExpected)
+	assert.Equal(t, uint(2), expected)
+}
+
+func TestEnsureJobCount_NoScale(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	metrics, _ := NewMockedMetrics(mockCtrl)
+	scaTgt := mock_scaler.NewMockScalingTarget(mockCtrl)
+
+	cfg := Config{JobName: "any", MinCount: 1, MaxCount: 5}
+	scaler, err := cfg.New(scaTgt, metrics)
+	require.NoError(t, err)
+	require.NotNil(t, scaler)
+
+	// Error in scaling target
+	scaTgt.EXPECT().GetJobCount("any").Return(uint(0), fmt.Errorf("Unable to determine job count"))
+	err = scaler.ensureJobCount()
+	assert.Error(t, err)
+
+	// No scale
+	desired := uint(1)
+	scaler.desiredScale = &desired
+	scaTgt.EXPECT().GetJobCount("any").Return(uint(1), nil)
+	err = scaler.ensureJobCount()
+	assert.NoError(t, err)
+
+}
+
+func TestEnsureJobCount_MinViolated(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	metrics, mocks := NewMockedMetrics(mockCtrl)
+	scaTgt := mock_scaler.NewMockScalingTarget(mockCtrl)
+
+	cfg := Config{JobName: "any", MinCount: 1, MaxCount: 5}
+	scaler, err := cfg.New(scaTgt, metrics)
+	require.NoError(t, err)
+	require.NotNil(t, scaler)
+
+	// Scale - min violated
+	desired := uint(1)
+	scaler.desiredScale = &desired
+	scalingTicketCounter := mock_metrics.NewMockCounter(mockCtrl)
+	scalingTicketCounter.EXPECT().Inc()
+	mocks.scalingTicketCount.EXPECT().WithLabelValues("added").Return(scalingTicketCounter)
+	scaTgt.EXPECT().GetJobCount("any").Return(uint(0), nil)
+	err = scaler.ensureJobCount()
+	assert.NoError(t, err)
+
+}
+
+func TestEnsureJobCount_MaxViolated(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	metrics, mocks := NewMockedMetrics(mockCtrl)
+	scaTgt := mock_scaler.NewMockScalingTarget(mockCtrl)
+
+	cfg := Config{JobName: "any", MinCount: 1, MaxCount: 5}
+	scaler, err := cfg.New(scaTgt, metrics)
+	require.NoError(t, err)
+	require.NotNil(t, scaler)
+
+	// Scale - max violated
+	desired := uint(1)
+	scaler.desiredScale = &desired
+	scalingTicketCounter := mock_metrics.NewMockCounter(mockCtrl)
+	scalingTicketCounter.EXPECT().Inc()
+	mocks.scalingTicketCount.EXPECT().WithLabelValues("added").Return(scalingTicketCounter)
+	scaTgt.EXPECT().GetJobCount("any").Return(uint(10), nil)
+	err = scaler.ensureJobCount()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
With this MR two things are added:
1. Immediately after restart sokar will check if the currently scaled count matches the min/ max definition of the job. If not, sokar will adjust the count accordingly.
2. Sokar watches continuously if the scaled count matches with its expectations. If not the scale will be adjusted accordingly. For example if the scale is changed due to a deployment, sokar will readjust immediately.