### PR TITLE
Job to generic name

### DIFF
--- a/config/Config.md
+++ b/config/Config.md
@@ -37,7 +37,7 @@
 
 ### [DEPRECATED] DummyScalingTarget
 
-* Will be replaced by Scaler.ScalingTarget
+- Will be replaced by Scaler.ScalingTarget
 
 |         |                                                               |
 | ------- | ------------------------------------------------------------- |
@@ -61,7 +61,6 @@
 | flag    | --sca.mode                                                                                                                                                                                                               |
 | env     | SK_SCA_MODE                                                                                                                                                                                                              |
 
-
 ## Nomad
 
 ### Server-Address
@@ -75,9 +74,9 @@
 | flag    | --nomad.server-address                     |
 | env     | SK_NOMAD_SERVER_ADDRESS                    |
 
-## Job
+## [DEPRECATED] Job
 
-### Name
+### [DEPRECATED] Name
 
 |         |                                   |
 | ------- | --------------------------------- |
@@ -88,7 +87,7 @@
 | flag    | --job.name                        |
 | env     | SK_JOB_NAME                       |
 
-### Min
+### [DEPRECATED] Min
 
 |         |                               |
 | ------- | ----------------------------- |
@@ -99,7 +98,7 @@
 | flag    | --job.min                     |
 | env     | SK_JOB_MIN                    |
 
-### Max
+### [DEPRECATED] Max
 
 |         |                               |
 | ------- | ----------------------------- |
@@ -109,6 +108,41 @@
 | default | 10                            |
 | flag    | --job.max                     |
 | env     | SK_JOB_MAX                    |
+
+## ScaleObject
+
+### Name
+
+|         |                                      |
+| ------- | ------------------------------------ |
+| name    | name                                 |
+| usage   | The name of the object to be scaled. |
+| type    | string                               |
+| default | ""                                   |
+| flag    | --scale-object.name                  |
+| env     | SK_SCALE_OBJECT_NAME                 |
+
+### Min
+
+|         |                                               |
+| ------- | --------------------------------------------- |
+| name    | min                                           |
+| usage   | The minimum count of the object to be scaled. |
+| type    | uint                                          |
+| default | 1                                             |
+| flag    | --scale-object.min                            |
+| env     | SK_SCALE_OBJECT_MIN                           |
+
+### Max
+
+|         |                                               |
+| ------- | --------------------------------------------- |
+| name    | max                                           |
+| usage   | The maximum count of the object to be scaled. |
+| type    | uint                                          |
+| default | 10                                            |
+| flag    | --scale-object.max                            |
+| env     | SK_SCALE_OBJECT_MAX                           |
 
 ## CapacityPlanner
 

--- a/config/config.go
+++ b/config/config.go
@@ -21,11 +21,10 @@ const (
 type Config struct {
 	Port                 int                  `json:"port,omitempty"`
 	Scaler               Scaler               `json:"scaler,omitempty"`
-	DummyScalingTarget   bool                 `json:"dummy_scaling_target,omitempty"`
 	DryRunMode           bool                 `json:"dry_run_mode,omitempty"`
 	Nomad                Nomad                `json:"nomad,omitempty"`
 	Logging              Logging              `json:"logging,omitempty"`
-	Job                  Job                  `json:"job,omitempty"`
+	ScaleObject          ScaleObject          `json:"scale_object,omitempty"`
 	ScaleAlertAggregator ScaleAlertAggregator `json:"scale_alert_aggregator,omitempty"`
 	CapacityPlanner      CapacityPlanner      `json:"capacity_planner,omitempty"`
 
@@ -45,8 +44,8 @@ type Nomad struct {
 	ServerAddr string `json:"server_addr,omitempty"`
 }
 
-// Job represents the definition for the job that should be scaled.
-type Job struct {
+// ScaleObject represents the definition for the object that should be scaled.
+type ScaleObject struct {
 	Name     string `json:"name,omitempty"`
 	MinCount uint   `json:"min_count,omitempty"`
 	MaxCount uint   `json:"max_count,omitempty"`
@@ -89,11 +88,12 @@ type CapacityPlanner struct {
 func NewDefaultConfig() Config {
 
 	cfg := Config{
-		Port:       11000,
-		DryRunMode: false,
-		Nomad:      Nomad{},
-		Logging:    Logging{Structured: false, UxTimestamp: false},
-		Job:        Job{},
+		Port:        11000,
+		DryRunMode:  false,
+		Nomad:       Nomad{},
+		Logging:     Logging{Structured: false, UxTimestamp: false},
+		ScaleObject: ScaleObject{},
+		Scaler:      Scaler{Mode: ScalerModeJob},
 		ScaleAlertAggregator: ScaleAlertAggregator{
 			EvaluationCycle:        time.Second * 1,
 			EvaluationPeriodFactor: 10,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,7 +10,7 @@ import (
 func Test_NewDefaultConfig(t *testing.T) {
 	config := NewDefaultConfig()
 	assert.Equal(t, 11000, config.Port)
-	assert.Equal(t, false, config.DummyScalingTarget)
+	assert.Equal(t, ScalerModeJob, config.Scaler.Mode)
 	assert.Equal(t, false, config.DryRunMode)
 	assert.Equal(t, float32(1), config.ScaleAlertAggregator.NoAlertScaleDamping)
 	assert.Equal(t, float32(10), config.ScaleAlertAggregator.UpScaleThreshold)

--- a/config/entries.go
+++ b/config/entries.go
@@ -28,6 +28,7 @@ var port = configEntry{
 	usage:        "Port where sokar is listening.",
 }
 
+// TODO: This is deprecated. Remove it.
 var dummyScalingTarget = configEntry{
 	name:         "dummy-scaling-target",
 	bindFlag:     true,
@@ -54,6 +55,32 @@ var nomadServerAddress = configEntry{
 	usage:        "Specifies the address of the nomad server.",
 }
 
+// ###################### Context: scale-object ####################################################
+var scaleObjectName = configEntry{
+	name:         "scale-object.name",
+	bindEnv:      true,
+	bindFlag:     true,
+	defaultValue: "",
+	usage:        "The name of the object to be scaled.",
+}
+
+var scaleObjectMin = configEntry{
+	name:         "scale-object.min",
+	bindEnv:      true,
+	bindFlag:     true,
+	defaultValue: 1,
+	usage:        "The minimum count of the object to be scaled.",
+}
+
+var scaleObjectMax = configEntry{
+	name:         "scale-object.max",
+	bindEnv:      true,
+	bindFlag:     true,
+	defaultValue: 10,
+	usage:        "The maximum count of the object to be scaled.",
+}
+
+// TODO: The whole job-section is deprecated. Remove it.
 // ###################### Context: job ####################################################
 var jobName = configEntry{
 	name:         "job.name",
@@ -67,7 +94,7 @@ var jobMin = configEntry{
 	name:         "job.min",
 	bindEnv:      true,
 	bindFlag:     true,
-	defaultValue: 1,
+	defaultValue: -1,
 	usage:        "The minimum scale of the job.",
 }
 
@@ -75,7 +102,7 @@ var jobMax = configEntry{
 	name:         "job.max",
 	bindEnv:      true,
 	bindFlag:     true,
-	defaultValue: 10,
+	defaultValue: -1,
 	usage:        "The maximum scale of the job.",
 }
 
@@ -190,10 +217,17 @@ var configEntries = []configEntry{
 	port,
 	dryRun,
 	scalerMode,
+	// TODO: Remove it.
 	dummyScalingTarget,
 	nomadServerAddress,
+	scaleObjectName,
+	scaleObjectMin,
+	scaleObjectMax,
+	// TODO: Remove it.
 	jobName,
+	// TODO: Remove it.
 	jobMin,
+	// TODO: Remove it.
 	jobMax,
 	capDownScaleCoolDown,
 	capUpScaleCoolDown,

--- a/config/fillCfg.go
+++ b/config/fillCfg.go
@@ -11,7 +11,6 @@ import (
 
 func (cfg *Config) fillCfgValues() error {
 	// Context: main
-	cfg.DummyScalingTarget = cfg.viper.GetBool(dummyScalingTarget.name)
 	cfg.DryRunMode = cfg.viper.GetBool(dryRun.name)
 	cfg.Port = cfg.viper.GetInt(port.name)
 
@@ -22,22 +21,42 @@ func (cfg *Config) fillCfgValues() error {
 	}
 	cfg.Scaler.Mode = scaMode
 
+	dummyScalingTargetEnabled := cfg.viper.GetBool(dummyScalingTarget.name)
+	if dummyScalingTargetEnabled {
+		cfg.Scaler.Mode = ScalerModeDataCenter
+	}
+
 	// Context: Nomad
 	cfg.Nomad.ServerAddr = cfg.viper.GetString(nomadServerAddress.name)
 
-	// Context: job
-	cfg.Job.Name = cfg.viper.GetString(jobName.name)
-	min := cfg.viper.GetInt(jobMin.name)
+	// Context: scale object
+	cfg.ScaleObject.Name = cfg.viper.GetString(scaleObjectName.name)
+	min := cfg.viper.GetInt(scaleObjectMin.name)
 	if min < 0 {
 		min = 0
 	}
-	cfg.Job.MinCount = uint(min)
+	cfg.ScaleObject.MinCount = uint(min)
 
-	max := cfg.viper.GetInt(jobMax.name)
+	max := cfg.viper.GetInt(scaleObjectMax.name)
 	if max < 0 {
 		max = 0
 	}
-	cfg.Job.MaxCount = uint(max)
+	cfg.ScaleObject.MaxCount = uint(max)
+
+	// Context: job
+	objName := cfg.viper.GetString(jobName.name)
+	if len(objName) > 0 {
+		cfg.ScaleObject.Name = objName
+	}
+	min = cfg.viper.GetInt(jobMin.name)
+	if min >= 0 {
+		cfg.ScaleObject.MinCount = uint(min)
+	}
+
+	max = cfg.viper.GetInt(jobMax.name)
+	if max >= 0 {
+		cfg.ScaleObject.MaxCount = uint(max)
+	}
 
 	// Context: CapacityPlanner
 	cfg.CapacityPlanner.DownScaleCooldownPeriod = cfg.viper.GetDuration(capDownScaleCoolDown.name)

--- a/examples/config/full.yaml
+++ b/examples/config/full.yaml
@@ -4,7 +4,7 @@ sca:
   mode: "job"
 nomad:
   server-address: "http://192.168.0.236:4646"
-job:
+scale-object:
   name: "fail-service"
   min: 1
   max: 10

--- a/examples/config/minimal.yaml
+++ b/examples/config/minimal.yaml
@@ -1,6 +1,6 @@
 nomad:
   server-address: "http://localhost:4646"
-job:
+scale-object:
   name: "fail-service"
   min: 1
   max: 10

--- a/main.go
+++ b/main.go
@@ -58,10 +58,7 @@ func main() {
 
 	logger.Info().Msg("4. Setup: Scaler")
 	scalerMode := cfg.Scaler.Mode
-	if cfg.DummyScalingTarget {
-		scalerMode = config.ScalerModeDataCenter
-	}
-	scaler := helper.Must(setupScaler(cfg.Job.Name, cfg.Job.MinCount, cfg.Job.MaxCount, cfg.Nomad.ServerAddr, scalerMode, loggingFactory)).(*scaler.Scaler)
+	scaler := helper.Must(setupScaler(cfg.ScaleObject.Name, cfg.ScaleObject.MinCount, cfg.ScaleObject.MaxCount, cfg.Nomad.ServerAddr, scalerMode, loggingFactory)).(*scaler.Scaler)
 
 	logger.Info().Msg("5. Setup: CapacityPlanner")
 	capaCfg := capacityPlanner.Config{


### PR DESCRIPTION
With this PR the term "job" is renamed to scale-object in order to be more generic.
This results in the deprecation of the configuration parameters --job.name, --job.min and --job.max