### PR TITLE
AWS region configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## v0.0.7 (TODO: Fill Date)
 
+- Config: With [#68](https://github.com/ThomasObenaus/sokar/issues/68) two new config parameters for scaling a nomad data-center on AWS where added. These are:
+  - `--sca.nomad.dc-aws.profile`
+  - `--sca.nomad.dc-aws.region`
+- Config: With [#68](https://github.com/ThomasObenaus/sokar/issues/68) some config parameters where marked as deprecated and will be removed in next release. These are:
+  - `--sca.mode` is deprecated, instead `--sca.nomad.mode` should be used
+  - `--nomad.server-address` is deprecated, instead `--sca.nomad.server-address` should be used
 - Config: With [#71](https://github.com/ThomasObenaus/sokar/issues/71) some deprecated config parameters where removed. These are:
-  - `--dummy-scaling-target`
-  - `-job.name` was replaced by `--scale-object.name`
-  - `-job.min` was replaced by `--scale-object.min`
-  - `-job.max` was replaced by `--scale-object.max`
+  - `--dummy-scaling-target` was removed
+  - `--job.name` was replaced by `--scale-object.name`
+  - `--job.min` was replaced by `--scale-object.min`
+  - `--job.max` was replaced by `--scale-object.max`
 
 ## v0.0.6 (2019-05-27)
 

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,13 @@ gen-metrics-md: sep
 	@python3 gen_metrics_doc.py > Metrics.md
 
 
-run: sep build
+run.dc: sep build
 	@echo "--> Run $(sokar_file_name)"
-	$(sokar_file_name) --config-file="examples/config/full.yaml" --nomad.server-address=$(nomad_server)
+	$(sokar_file_name) --config-file="examples/config/full.yaml" --sca.nomad.server-address=$(nomad_server) --sca.nomad.mode="dc"
+
+run.job: sep build
+	@echo "--> Run $(sokar_file_name)"
+	$(sokar_file_name) --config-file="examples/config/full.yaml" --sca.nomad.server-address=$(nomad_server)
 
 docker.build: sep
 	@echo "--> Build docker image thobe/sokar"
@@ -86,7 +90,7 @@ docker.build: sep
 
 docker.run: sep
 	@echo "--> Run docker image $(docker_image)"
-	@docker run --rm --name=sokar -p 11000:11000 $(docker_image) --nomad.server-address=$(nomad_server)
+	@docker run --rm --name=sokar -p 11000:11000 $(docker_image) --sca.nomad.server-address=$(nomad_server)
 
 docker.push: sep
 	@echo "--> Tag image to thobe/sokar:$(tag)"

--- a/config/Config.md
+++ b/config/Config.md
@@ -37,7 +37,61 @@
 
 ## Scaler
 
-### ScalingTarget
+### Nomad
+
+* This section contains the configuration parameters for nomad based scalers (i.e. job or data-center on AWS).
+
+#### Mode
+
+|         |                                                                                                                                                                                                                          |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| name    | mode                                                                                                                                                                                                                     |
+| usage   | Scaling target mode is either job based or data-center (worker/ instance) based scaling. In data-center (dc) mode the nomad workers will be scaled. In job mode the number of allocations for this job will be adjusted. |
+| type    | string (enum: job \| dc )                                                                                                                                                                                                |
+| default | job                                                                                                                                                                                                                      |
+| flag    | --sca.nomad.mode                                                                                                                                                                                                         |
+| env     | SK_SCA_NOMAD_MODE                                                                                                                                                                                                        |
+
+#### Server-Address
+
+|         |                                            |
+| ------- | ------------------------------------------ |
+| name    | server-address                             |
+| usage   | Specifies the address of the nomad server. |
+| type    | string                                     |
+| default | ""                                         |
+| flag    | --sca.nomad.server-address                 |
+| env     | SK_SCA_NOMAD_SERVER_ADDRESS                |
+
+#### Data-Center AWS
+
+* The parameters in this section are used to configure the scaler that is used to scale a data-center hosted on AWS
+
+##### Profile
+
+|         |                                                                                                                                                                                                                                                                                                                                                    |
+| ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name    | profile                                                                                                                                                                                                                                                                                                                                            |
+| usage   | This parameter represents the name of the aws profile that shall be used to access the resources to scale the data-center. This parameter is optional. If it is empty the instance where sokar runs on has to have enough permissions to access the resources (ASG) for scaling. In this case the AWSRegion parameter has to be specified as well. |
+| type    | string                                                                                                                                                                                                                                                                                                                                             |
+| default | ""                                                                                                                                                                                                                                                                                                                                                 |
+| flag    | --sca.nomad.dc-aws.profile                                                                                                                                                                                                                                                                                                                         |
+| env     | SK_SCA_NOMAD_DC_AWS_PROFILE                                                                                                                                                                                                                                                                                                                        |
+
+##### Region
+
+|         |                                                                                                                                                                                    |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name    | region                                                                                                                                                                             |
+| usage   | This is an optional parameter and is regarded only if the parameter AWSProfile is empty. The AWSRegion has to specify the region in which the data-center to be scaled resides in. |
+| type    | string                                                                                                                                                                             |
+| default | ""                                                                                                                                                                                 |
+| flag    | --sca.nomad.dc-aws.region                                                                                                                                                          |
+| env     | SK_SCA_NOMAD_DC_AWS_REGION                                                                                                                                                         |
+
+### [DEPRECATED] ScalingTarget
+
+* Replaced by `--sca.nomad.mode`
 
 |         |                                                                                                                                                                                                                          |
 | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -48,9 +102,11 @@
 | flag    | --sca.mode                                                                                                                                                                                                               |
 | env     | SK_SCA_MODE                                                                                                                                                                                                              |
 
-## Nomad
+## [DEPRECATED] Nomad
 
-### Server-Address
+### [DEPRECATED] Server-Address
+
+* Replaced by `--sca.nomad.server-address`
 
 |         |                                            |
 | ------- | ------------------------------------------ |

--- a/config/config.go
+++ b/config/config.go
@@ -19,9 +19,10 @@ const (
 
 // Config is a structure containing the configuration for sokar
 type Config struct {
-	Port                 int                  `json:"port,omitempty"`
-	Scaler               Scaler               `json:"scaler,omitempty"`
-	DryRunMode           bool                 `json:"dry_run_mode,omitempty"`
+	Port       int    `json:"port,omitempty"`
+	Scaler     Scaler `json:"scaler,omitempty"`
+	DryRunMode bool   `json:"dry_run_mode,omitempty"`
+	// TODO: [DEPRECATED] Remove this entry
 	Nomad                Nomad                `json:"nomad,omitempty"`
 	Logging              Logging              `json:"logging,omitempty"`
 	ScaleObject          ScaleObject          `json:"scale_object,omitempty"`
@@ -36,11 +37,28 @@ type Config struct {
 
 // Scaler represents the config for the scaler/ ScalingTarget
 type Scaler struct {
-	Mode ScalerMode `json:"mode,omitempty"`
+	// TODO: [DEPRECATED] Remove this entry
+	Mode  ScalerMode `json:"mode,omitempty"`
+	Nomad SCANomad   `json:"nomad,omitempty"`
+}
+
+// SCANomad represents the parameters for a nomad based scaler (job or data-center).
+type SCANomad struct {
+	Mode          ScalerMode            `json:"mode,omitempty"`
+	ServerAddr    string                `json:"server_addr,omitempty"`
+	DataCenterAWS SCANomadDataCenterAWS `json:"datacenter_aws,omitempty"`
+}
+
+// SCANomadDataCenterAWS represents the parameters needed for the nomad based scaler for mode data-center running on AWS.
+type SCANomadDataCenterAWS struct {
+	AWSProfile string `json:"aws_profile,omitempty"`
+	AWSRegion  string `json:"aws_region,omitempty"`
 }
 
 // Nomad represents the configuration for the scaling target nomad
+// TODO: [DEPRECATED] Remove this entry
 type Nomad struct {
+	// TODO: [DEPRECATED] Remove this entry
 	ServerAddr string `json:"server_addr,omitempty"`
 }
 
@@ -93,7 +111,9 @@ func NewDefaultConfig() Config {
 		Nomad:       Nomad{},
 		Logging:     Logging{Structured: false, UxTimestamp: false},
 		ScaleObject: ScaleObject{},
-		Scaler:      Scaler{Mode: ScalerModeJob},
+		Scaler: Scaler{
+			Nomad: SCANomad{Mode: ScalerModeJob},
+		},
 		ScaleAlertAggregator: ScaleAlertAggregator{
 			EvaluationCycle:        time.Second * 1,
 			EvaluationPeriodFactor: 10,

--- a/config/config.go
+++ b/config/config.go
@@ -51,8 +51,8 @@ type SCANomad struct {
 
 // SCANomadDataCenterAWS represents the parameters needed for the nomad based scaler for mode data-center running on AWS.
 type SCANomadDataCenterAWS struct {
-	AWSProfile string `json:"aws_profile,omitempty"`
-	AWSRegion  string `json:"aws_region,omitempty"`
+	Profile string `json:"profile,omitempty"`
+	Region  string `json:"region,omitempty"`
 }
 
 // Nomad represents the configuration for the scaling target nomad

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -10,7 +10,7 @@ import (
 func Test_NewDefaultConfig(t *testing.T) {
 	config := NewDefaultConfig()
 	assert.Equal(t, 11000, config.Port)
-	assert.Equal(t, ScalerModeJob, config.Scaler.Mode)
+	assert.Equal(t, ScalerModeJob, config.Scaler.Nomad.Mode)
 	assert.Equal(t, false, config.DryRunMode)
 	assert.Equal(t, float32(1), config.ScaleAlertAggregator.NoAlertScaleDamping)
 	assert.Equal(t, float32(10), config.ScaleAlertAggregator.UpScaleThreshold)

--- a/config/entries.go
+++ b/config/entries.go
@@ -39,7 +39,7 @@ var scalerMode = configEntry{
 }
 
 var scaNomadDataCenterAWSProfile = configEntry{
-	name:         "sca.nomad.dc-aws.aws-profile",
+	name:         "sca.nomad.dc-aws.profile",
 	bindEnv:      true,
 	bindFlag:     true,
 	defaultValue: "",
@@ -47,7 +47,7 @@ var scaNomadDataCenterAWSProfile = configEntry{
 }
 
 var scaNomadDataCenterAWSRegion = configEntry{
-	name:         "sca.nomad.dc-aws.aws-region",
+	name:         "sca.nomad.dc-aws.region",
 	bindEnv:      true,
 	bindFlag:     true,
 	defaultValue: "eu-central-1",

--- a/config/entries.go
+++ b/config/entries.go
@@ -29,6 +29,7 @@ var port = configEntry{
 }
 
 // ###################### Context: scaler ####################################################
+// TODO: [DEPRECATED] Remove this entry
 var scalerMode = configEntry{
 	name:         "sca.mode",
 	bindEnv:      true,
@@ -37,6 +38,39 @@ var scalerMode = configEntry{
 	usage:        "Scaling target mode is either job based or data-center (worker/ instance) based scaling. In data-center (dc) mode the nomad workers will be scaled. In job mode the number of allocations for this job will be adjusted.",
 }
 
+var scaNomadDataCenterAWSProfile = configEntry{
+	name:         "sca.nomad.dc-aws.aws-profile",
+	bindEnv:      true,
+	bindFlag:     true,
+	defaultValue: "",
+	usage:        "This parameter represents the name of the aws profile that shall be used to access the resources to scale the data-center. This parameter is optional. If it is empty the instance where sokar runs on has to have enough permissions to access the resources (ASG) for scaling. In this case the AWSRegion parameter has to be specified as well.",
+}
+
+var scaNomadDataCenterAWSRegion = configEntry{
+	name:         "sca.nomad.dc-aws.aws-region",
+	bindEnv:      true,
+	bindFlag:     true,
+	defaultValue: "eu-central-1",
+	usage:        "This is an optional parameter and is regarded only if the parameter AWSProfile is empty. The AWSRegion has to specify the region in which the data-center to be scaled resides in.",
+}
+
+var scaNomadMode = configEntry{
+	name:         "sca.nomad.mode",
+	bindEnv:      true,
+	bindFlag:     true,
+	defaultValue: "job",
+	usage:        "Scaling target mode is either job based or data-center (worker/ instance) based scaling. In data-center (dc) mode the nomad workers will be scaled. In job mode the number of allocations for this job will be adjusted.",
+}
+
+var scaNomadModeServerAddress = configEntry{
+	name:         "sca.nomad.server-address",
+	bindEnv:      true,
+	bindFlag:     true,
+	defaultValue: "",
+	usage:        "Specifies the address of the nomad server.",
+}
+
+// TODO: [DEPRECATED] Remove this entry
 // ###################### Context: nomad ####################################################
 var nomadServerAddress = configEntry{
 	name:         "nomad.server-address",
@@ -181,7 +215,9 @@ var configEntries = []configEntry{
 	configFile,
 	port,
 	dryRun,
+	// TODO: [DEPRECATED] Remove this entry
 	scalerMode,
+	// TODO: [DEPRECATED] Remove this entry
 	nomadServerAddress,
 	scaleObjectName,
 	scaleObjectMin,
@@ -199,4 +235,8 @@ var configEntries = []configEntry{
 	saaCleanupCylce,
 	saaScaleAlerts,
 	saaAlertExpirationTime,
+	scaNomadDataCenterAWSProfile,
+	scaNomadDataCenterAWSRegion,
+	scaNomadMode,
+	scaNomadModeServerAddress,
 }

--- a/config/fillCfg.go
+++ b/config/fillCfg.go
@@ -36,8 +36,8 @@ func (cfg *Config) fillCfgValues() error {
 		cfg.Scaler.Nomad.ServerAddr = nomadSrvAddressCfg
 	}
 
-	cfg.Scaler.Nomad.DataCenterAWS.AWSProfile = cfg.viper.GetString(scaNomadDataCenterAWSProfile.name)
-	cfg.Scaler.Nomad.DataCenterAWS.AWSRegion = cfg.viper.GetString(scaNomadDataCenterAWSRegion.name)
+	cfg.Scaler.Nomad.DataCenterAWS.Profile = cfg.viper.GetString(scaNomadDataCenterAWSProfile.name)
+	cfg.Scaler.Nomad.DataCenterAWS.Region = cfg.viper.GetString(scaNomadDataCenterAWSRegion.name)
 
 	// Context: scale object
 	cfg.ScaleObject.Name = cfg.viper.GetString(scaleObjectName.name)

--- a/config/fillCfg.go
+++ b/config/fillCfg.go
@@ -15,14 +15,29 @@ func (cfg *Config) fillCfgValues() error {
 	cfg.Port = cfg.viper.GetInt(port.name)
 
 	// Context: Scaler
-	scaMode, err := strToScalerMode(cfg.viper.GetString(scalerMode.name))
+	scaModeStr := cfg.viper.GetString(scalerMode.name)
+	scaNomadModeStr := cfg.viper.GetString(scaNomadMode.name)
+
+	// TODO: Remove since scalerMode.name is deprecated
+	// Currently the new parameter overrides the old one only if the old is not dc and the new is not empty.
+	if len(scaNomadModeStr) > 0 && scaModeStr != "dc" {
+		scaModeStr = scaNomadModeStr
+	}
+
+	scaMode, err := strToScalerMode(scaModeStr)
 	if err != nil {
 		return err
 	}
-	cfg.Scaler.Mode = scaMode
+	cfg.Scaler.Nomad.Mode = scaMode
 
-	// Context: Nomad
-	cfg.Nomad.ServerAddr = cfg.viper.GetString(nomadServerAddress.name)
+	cfg.Scaler.Nomad.ServerAddr = cfg.viper.GetString(nomadServerAddress.name)
+	nomadSrvAddressCfg := cfg.viper.GetString(scaNomadModeServerAddress.name)
+	if len(nomadSrvAddressCfg) > 0 {
+		cfg.Scaler.Nomad.ServerAddr = nomadSrvAddressCfg
+	}
+
+	cfg.Scaler.Nomad.DataCenterAWS.AWSProfile = cfg.viper.GetString(scaNomadDataCenterAWSProfile.name)
+	cfg.Scaler.Nomad.DataCenterAWS.AWSRegion = cfg.viper.GetString(scaNomadDataCenterAWSRegion.name)
 
 	// Context: scale object
 	cfg.ScaleObject.Name = cfg.viper.GetString(scaleObjectName.name)

--- a/config/fillCfg_test.go
+++ b/config/fillCfg_test.go
@@ -34,15 +34,15 @@ func Test_FillCfg_Flags(t *testing.T) {
 		"--nomad.server-address=INVALID",
 		"--sca.nomad.mode=dc",
 		"--sca.nomad.server-address=http://nomad",
-		"--sca.nomad.dc-aws.aws-region=region-test",
-		"--sca.nomad.dc-aws.aws-profile=profile-test",
+		"--sca.nomad.dc-aws.region=region-test",
+		"--sca.nomad.dc-aws.profile=profile-test",
 	}
 
 	err := cfg.ReadConfig(args)
 	assert.NoError(t, err)
 	assert.Equal(t, ScalerModeDataCenter, cfg.Scaler.Nomad.Mode)
-	assert.Equal(t, "profile-test", cfg.Scaler.Nomad.DataCenterAWS.AWSProfile)
-	assert.Equal(t, "region-test", cfg.Scaler.Nomad.DataCenterAWS.AWSRegion)
+	assert.Equal(t, "profile-test", cfg.Scaler.Nomad.DataCenterAWS.Profile)
+	assert.Equal(t, "region-test", cfg.Scaler.Nomad.DataCenterAWS.Region)
 	assert.Equal(t, "http://nomad", cfg.Scaler.Nomad.ServerAddr)
 	assert.True(t, cfg.DryRunMode)
 	assert.Equal(t, 1000, cfg.Port)

--- a/examples/config/full.yaml
+++ b/examples/config/full.yaml
@@ -5,7 +5,7 @@ sca:
     mode: "job"
     server-address: "http://192.168.0.236:4646"
     datacenter-aws:
-      aws-region: "us-east-1"
+      region: "us-east-1"
 scale-object:
   name: "fail-service"
   min: 1

--- a/examples/config/full.yaml
+++ b/examples/config/full.yaml
@@ -1,9 +1,11 @@
 dry-run: false
 port: 11000
 sca:
-  mode: "job"
-nomad:
-  server-address: "http://192.168.0.236:4646"
+  nomad:
+    mode: "job"
+    server-address: "http://192.168.0.236:4646"
+    datacenter-aws:
+      aws-region: "us-east-1"
 scale-object:
   name: "fail-service"
   min: 1

--- a/examples/config/minimal.yaml
+++ b/examples/config/minimal.yaml
@@ -1,5 +1,6 @@
-nomad:
-  server-address: "http://localhost:4646"
+sca:
+  nomad:
+    server-address: "http://192.168.0.236:4646"
 scale-object:
   name: "fail-service"
   min: 1

--- a/main.go
+++ b/main.go
@@ -219,8 +219,10 @@ func setupScalingTarget(nomadSrvAddr string, mode config.ScalerMode, logF loggin
 	var scalingTarget scaler.ScalingTarget
 
 	if mode == config.ScalerModeDataCenter {
+		// TODO: Remove hard-coded value
+		awsRegion := "eu-central-1"
 
-		cfg := nomadWorker.Config{Logger: logF.NewNamedLogger("sokar.nomadWorker")}
+		cfg := nomadWorker.Config{Logger: logF.NewNamedLogger("sokar.nomadWorker"), AWSRegion: awsRegion}
 		nomadWorker, err := cfg.New()
 		if err != nil {
 			return nil, fmt.Errorf("Failed setting up nomad worker connector: %s", err)

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func setupScalingTarget(cfg config.Scaler, logF logging.LoggerFactory) (scaler.S
 	var scalingTarget scaler.ScalingTarget
 
 	if cfg.Nomad.Mode == config.ScalerModeDataCenter {
-		cfg := nomadWorker.Config{Logger: logF.NewNamedLogger("sokar.nomadWorker"), AWSRegion: cfg.Nomad.DataCenterAWS.AWSRegion, AWSProfile: cfg.Nomad.DataCenterAWS.AWSProfile}
+		cfg := nomadWorker.Config{Logger: logF.NewNamedLogger("sokar.nomadWorker"), AWSRegion: cfg.Nomad.DataCenterAWS.Region, AWSProfile: cfg.Nomad.DataCenterAWS.Profile}
 		nomadWorker, err := cfg.New()
 		if err != nil {
 			return nil, fmt.Errorf("Failed setting up nomad worker connector: %s", err)

--- a/main_test.go
+++ b/main_test.go
@@ -120,7 +120,7 @@ func Test_SetupScalingTarget(t *testing.T) {
 		Nomad: config.SCANomad{
 			ServerAddr:    "http://nomad",
 			Mode:          config.ScalerModeDataCenter,
-			DataCenterAWS: config.SCANomadDataCenterAWS{AWSRegion: "eu-central-1"},
+			DataCenterAWS: config.SCANomadDataCenterAWS{Region: "eu-central-1"},
 		},
 	}
 	logF.EXPECT().NewNamedLogger(gomock.Any()).Times(1)

--- a/nomadWorker/awsAsg_test.go
+++ b/nomadWorker/awsAsg_test.go
@@ -20,7 +20,7 @@ func Test_CreateAutoScaling(t *testing.T) {
 	assert.Nil(t, as)
 
 	//  no session
-	sess, _ := newAWSSession()
+	sess, _ := newAWSSession("eu-central-1")
 	as = asgF.CreateAutoScaling(sess)
 	assert.NotNil(t, as)
 }

--- a/nomadWorker/connector.go
+++ b/nomadWorker/connector.go
@@ -1,6 +1,8 @@
 package nomadWorker
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/rs/zerolog"
 	iface "github.com/thomasobenaus/sokar/nomadWorker/iface"
@@ -31,24 +33,40 @@ type Connector struct {
 	// gain permission to access the needed AWS resources.
 	// If empty the default credentials will be used.
 	awsProfile string
+
+	// awsRegion is the region where the datacenter to be scaled is located in.
+	awsRegion string
 }
 
 // Config contains the main configuration for the nomad worker connector
 type Config struct {
-	Logger     zerolog.Logger
+	Logger zerolog.Logger
+
+	// AWSProfile represents the name of the aws profile that shall be used to access the resources to scale the data-center.
+	// This parameter is optional. If it is empty the instance where sokar runs on has to have enough permissions to access the
+	// resources (ASG) for scaling. In this case the AWSRegion parameter has to be specified as well.
 	AWSProfile string
+
+	// AWSRegion is an optional parameter and is regarded only if the parameter AWSProfile is empty.
+	// The AWSRegion has to specify the region in which the data-center to be scaled resides in.
+	AWSRegion string
 }
 
 // New creates a new nomad connector
 func (cfg *Config) New() (*Connector, error) {
 
+	if len(cfg.AWSProfile) == 0 && len(cfg.AWSRegion) == 0 {
+		return nil, fmt.Errorf("The parameters AWSRegion and AWSProfile are empty")
+	}
+
 	nc := &Connector{
 		log:                        cfg.Logger,
 		tagKey:                     "datacenter",
+		autoScalingFactory:         &autoScalingFactoryImpl{},
 		fnCreateSession:            newAWSSession,
 		fnCreateSessionFromProfile: newAWSSessionFromProfile,
 		awsProfile:                 cfg.AWSProfile,
-		autoScalingFactory:         &autoScalingFactoryImpl{},
+		awsRegion:                  cfg.AWSRegion,
 	}
 
 	cfg.Logger.Info().Msg("Setting up nomad worker connector ... done")

--- a/nomadWorker/connector.go
+++ b/nomadWorker/connector.go
@@ -20,7 +20,7 @@ type Connector struct {
 
 	// fnCreateSession is the function that should be used to create the aws session
 	// which is needed to access the aws resources.
-	fnCreateSession func() (*session.Session, error)
+	fnCreateSession func(region string) (*session.Session, error)
 
 	// fnCreateSessionFromProfile is the function that should be used to create the aws session
 	// which is needed to access the aws resources.

--- a/nomadWorker/connector_test.go
+++ b/nomadWorker/connector_test.go
@@ -8,9 +8,20 @@ import (
 
 func TestNewConnector(t *testing.T) {
 
+	// AWSProfile and AWSRegion not specified
 	cfg := Config{}
 	connector, err := cfg.New()
 
+	assert.Nil(t, connector)
+	assert.Error(t, err)
+
+	cfg = Config{AWSProfile: "test"}
+	connector, err = cfg.New()
+	assert.NotNil(t, connector)
+	assert.NoError(t, err)
+
+	cfg = Config{AWSRegion: "test-region"}
+	connector, err = cfg.New()
 	assert.NotNil(t, connector)
 	assert.NoError(t, err)
 }

--- a/nomadWorker/session.go
+++ b/nomadWorker/session.go
@@ -1,6 +1,8 @@
 package nomadWorker
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
@@ -14,11 +16,13 @@ func newAWSSessionFromProfile(profile string) (*session.Session, error) {
 	return session.NewSessionWithOptions(sessionOpts)
 }
 
-func newAWSSession() (*session.Session, error) {
+func newAWSSession(region string) (*session.Session, error) {
+	if len(region) == 0 {
+		return nil, fmt.Errorf("Required region parameter is empty")
+	}
+
 	verboseCredErrors := true
 
-	// HACK: should not be hard-coded
-	region := "eu-central-1"
 	cfg := aws.Config{CredentialsChainVerboseErrors: &verboseCredErrors, Region: &region}
 	sessionOpts := session.Options{Config: cfg, SharedConfigState: session.SharedConfigEnable}
 

--- a/nomadWorker/session_test.go
+++ b/nomadWorker/session_test.go
@@ -14,7 +14,12 @@ func TestAWSNewSessionFromProfile(t *testing.T) {
 }
 
 func TestAWSNewSession(t *testing.T) {
-	session, err := newAWSSession()
+
+	session, err := newAWSSession("")
+	assert.Error(t, err)
+	assert.Nil(t, session)
+
+	session, err = newAWSSession("eu-central-1")
 	assert.NoError(t, err)
 	assert.NotNil(t, session)
 	assert.True(t, *session.Config.CredentialsChainVerboseErrors)

--- a/nomadWorker/workers.go
+++ b/nomadWorker/workers.go
@@ -111,8 +111,7 @@ func (c *Connector) createSession() (*session.Session, error) {
 			return nil, fmt.Errorf("fnCreateSession is nil")
 		}
 
-		// HACK: Remove hardcoded region
-		session, err = c.fnCreateSession("eu-central-1")
+		session, err = c.fnCreateSession(c.awsRegion)
 	}
 	return session, err
 }

--- a/nomadWorker/workers.go
+++ b/nomadWorker/workers.go
@@ -111,7 +111,8 @@ func (c *Connector) createSession() (*session.Session, error) {
 			return nil, fmt.Errorf("fnCreateSession is nil")
 		}
 
-		session, err = c.fnCreateSession()
+		// HACK: Remove hardcoded region
+		session, err = c.fnCreateSession("eu-central-1")
 	}
 	return session, err
 }

--- a/nomadWorker/workers_test.go
+++ b/nomadWorker/workers_test.go
@@ -35,6 +35,7 @@ func Test_CreateSession(t *testing.T) {
 
 	// success, no profile
 	connector = Connector{
+		awsRegion:       "xyz",
 		fnCreateSession: newAWSSession,
 	}
 	sess, err = connector.createSession()
@@ -50,7 +51,7 @@ func TestSetScalingObjectCount(t *testing.T) {
 	asgFactory := mock_nomadWorker.NewMockAutoScalingFactory(mockCtrl)
 	asgIF := mock_nomadWorker.NewMockAutoScaling(mockCtrl)
 
-	cfg := Config{}
+	cfg := Config{AWSProfile: "xyz"}
 	connector, err := cfg.New()
 	require.NotNil(t, connector)
 	require.NoError(t, err)
@@ -97,7 +98,7 @@ func TestGetScalingObjectCount(t *testing.T) {
 	asgFactory := mock_nomadWorker.NewMockAutoScalingFactory(mockCtrl)
 	asgIF := mock_nomadWorker.NewMockAutoScaling(mockCtrl)
 
-	cfg := Config{}
+	cfg := Config{AWSProfile: "xyz"}
 	connector, err := cfg.New()
 	require.NotNil(t, connector)
 	require.NoError(t, err)
@@ -146,7 +147,7 @@ func Test_IsScalingObjectDead(t *testing.T) {
 	asgFactory := mock_nomadWorker.NewMockAutoScalingFactory(mockCtrl)
 	asgIF := mock_nomadWorker.NewMockAutoScaling(mockCtrl)
 
-	cfg := Config{}
+	cfg := Config{AWSProfile: "xyz"}
 	connector, err := cfg.New()
 	require.NotNil(t, connector)
 	require.NoError(t, err)


### PR DESCRIPTION
With this PR the needed parameters for configuring a scaler for nomad data-center hosted on AWS where added.

These are:
  - `--sca.nomad.dc-aws.profile`
  - `--sca.nomad.dc-aws.region`

And some config parameters where marked as deprecated and will be removed in next release. These are:
  - `--sca.mode` is deprecated, instead `--sca.nomad.mode` should be used
  - `--nomad.server-address` is deprecated, instead `--sca.nomad.server-address` should be used