### PR TITLE
CFG Refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ run.aws-ec2: sep build ## Builds + runs sokar locally in aws ec2 mode.
 
 run.nomad-dc: sep build ## Builds + runs sokar locally in data-center mode.
 	@echo "--> Run $(sokar_file_name)"
-	$(sokar_file_name) --config-file="examples/config/full.yaml" --sca.nomad.server-address=$(nomad_server) --sca.mode="nomad-dc" --scale-object.name="private-services" --sca.nomad.dc-aws.profile="integration" --scale-object.max=22 --dry-run=true --sca.watcher-interval=20m
+	$(sokar_file_name) --config-file="examples/config/full.yaml" --sca.nomad.server-address=$(nomad_server) --sca.mode="nomad-dc"
 
 run.nomad-job: sep build ## Builds + runs sokar locally in job mode.
 	@echo "--> Run $(sokar_file_name)"

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help: ## Prints the help
 .PHONY: test
 test: sep gen-mocks ## Runs all unittests and generates a coverage report.
 	@echo "--> Run the unit-tests"
-	@go test ./config ./alertmanager ./nomad ./logging ./scaler ./helper ./scaleAlertAggregator ./sokar ./capacityPlanner ./aws ./awsEc2 ./nomadWorker ./ -covermode=count -coverprofile=coverage.out
+	@go test ./config ./alertmanager ./nomad ./logging ./scaler ./helper ./scaleAlertAggregator ./sokar ./capacityPlanner ./aws ./awsEc2 ./nomadWorker ./api ./ -covermode=count -coverprofile=coverage.out
 
 cover-upload: sep ## Uploads the unittest coverage to coveralls (for this the SOKAR_COVERALLS_REPO_TOKEN has to be set correctly).
 	# for this to get working you have to export the repo_token for your repo at coveralls.io

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ tag := $(shell git describe --tags)
 branch := $(shell git branch | grep \* | cut -d ' ' -f2)
 revision := $(rev)$(flag)
 build_info := $(build_time)_$(revision)
-nomad_server := "https://nomad.integration.eu.pcc-nav.cloud"#"http://${LOCAL_IP}:4646"
+nomad_server := "http://${LOCAL_IP}:4646"
 
 all: tools test build finish
 

--- a/alertmanager/connector.go
+++ b/alertmanager/connector.go
@@ -19,16 +19,23 @@ type Connector struct {
 	handleFuncs []saa.ScaleAlertHandleFunc
 }
 
-// Config cfg for the connector
-type Config struct {
-	Logger zerolog.Logger
+// Option represents an option for the alertmanager
+type Option func(c *Connector)
+
+// WithLogger adds a configured Logger to the alertmanager
+func WithLogger(logger zerolog.Logger) Option {
+	return func(c *Connector) {
+		c.logger = logger
+	}
 }
 
 // New creates a new instance of the prometheus/alertmanager Connector
-func (cfg Config) New() *Connector {
-	return &Connector{
-		logger: cfg.Logger,
+func New(options ...Option) *Connector {
+	connector := Connector{logger: zerolog.Logger{}}
+	for _, opt := range options {
+		opt(&connector)
 	}
+	return &connector
 }
 
 // Register is used to register the given handler func.

--- a/alertmanager/connector.go
+++ b/alertmanager/connector.go
@@ -31,7 +31,8 @@ func WithLogger(logger zerolog.Logger) Option {
 
 // New creates a new instance of the prometheus/alertmanager Connector
 func New(options ...Option) *Connector {
-	connector := Connector{logger: zerolog.Logger{}}
+	connector := Connector{}
+	// apply the options
 	for _, opt := range options {
 		opt(&connector)
 	}

--- a/alertmanager/connector_test.go
+++ b/alertmanager/connector_test.go
@@ -5,21 +5,28 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	saa "github.com/thomasobenaus/sokar/scaleAlertAggregator"
 )
 
 func TestNewConnector(t *testing.T) {
-
-	cfg := Config{}
-	connector := cfg.New()
-
+	connector := New()
 	assert.NotNil(t, connector)
+}
+
+func Test_WithLogger(t *testing.T) {
+
+	logger := zerolog.New(os.Stdout).Level(zerolog.DebugLevel)
+	am := New(WithLogger(logger))
+	require.NotNil(t, am)
+	assert.Equal(t, zerolog.DebugLevel, logger.GetLevel())
 }
 
 func Test_GenReceiver(t *testing.T) {
@@ -32,8 +39,7 @@ func Test_GenReceiver(t *testing.T) {
 
 func Test_FireScaleAlert(t *testing.T) {
 
-	cfg := Config{}
-	connector := cfg.New()
+	connector := New()
 	require.NotNil(t, connector)
 
 	emitter := "ALERTMANAGER"
@@ -62,8 +68,7 @@ func Test_FireScaleAlert(t *testing.T) {
 }
 func Test_HandleScaleAlert_Invalid(t *testing.T) {
 
-	cfg := Config{}
-	connector := cfg.New()
+	connector := New()
 	require.NotNil(t, connector)
 
 	req := httptest.NewRequest("GET", "http://example.com/foo", nil)
@@ -84,8 +89,7 @@ func Test_HandleScaleAlert_Invalid(t *testing.T) {
 
 func Test_HandleScaleAlert_Success(t *testing.T) {
 
-	cfg := Config{}
-	connector := cfg.New()
+	connector := New()
 	require.NotNil(t, connector)
 	alertName := "ABC"
 	startsAt := time.Now()

--- a/api/api.go
+++ b/api/api.go
@@ -36,7 +36,7 @@ func (api *API) GetName() string {
 }
 
 // Stop stops/ tears down the api server
-func (api *API) Stop() {
+func (api *API) Stop() error {
 
 	// context: wait for 3 seconds
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -44,8 +44,9 @@ func (api *API) Stop() {
 
 	err := api.srv.Shutdown(ctx)
 	if err != nil {
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 // Run starts the api server for sokar

--- a/api/api.go
+++ b/api/api.go
@@ -20,14 +20,29 @@ type API struct {
 	stopChan chan struct{}
 }
 
+// Option represents an option for the api
+type Option func(api *API)
+
+// WithLogger adds a configured Logger to the api
+func WithLogger(logger zerolog.Logger) Option {
+	return func(api *API) {
+		api.logger = logger
+	}
+}
+
 // New creates a new runnable api server
-func New(port int, logger zerolog.Logger) *API {
-	return &API{
+func New(port int, options ...Option) *API {
+	api := API{
 		Router:   httprouter.New(),
 		port:     port,
-		logger:   logger,
 		stopChan: make(chan struct{}, 1),
 	}
+
+	// apply the options
+	for _, opt := range options {
+		opt(&api)
+	}
+	return &api
 }
 
 // GetName returns the name of this component

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	api := New(12345)
+	assert.NotNil(t, api)
+}
+
+func TestWithLogger(t *testing.T) {
+
+	logger := zerolog.New(os.Stdout).Level(zerolog.DebugLevel)
+	api := New(1234, WithLogger(logger))
+	require.NotNil(t, api)
+	assert.Equal(t, zerolog.DebugLevel, logger.GetLevel())
+}
+
+func TestRunJoinStop(t *testing.T) {
+
+	api := New(1234)
+	require.NotNil(t, api)
+
+	api.Run()
+	start := time.Now()
+	api.Stop()
+	api.Join()
+
+	assert.WithinDuration(t, start.Add(time.Millisecond*500), time.Now(), time.Second*1)
+}

--- a/awsEc2/connector.go
+++ b/awsEc2/connector.go
@@ -39,50 +39,65 @@ type Connector struct {
 	awsRegion string
 }
 
-// Config contains the main configuration for the nomad worker connector
-type Config struct {
-	Logger zerolog.Logger
+// Option represents an option for the awsEc2 Connector
+type Option func(c *Connector)
 
-	// AWSProfile represents the name of the aws profile that shall be used to access the resources to scale the data-center.
-	// This parameter is optional. If it is empty the instance where sokar runs on has to have enough permissions to access the
-	// resources (ASG) for scaling. In this case the AWSRegion parameter has to be specified as well.
-	AWSProfile string
+// WithLogger adds a configured Logger to the awsEc2 Connector
+func WithLogger(logger zerolog.Logger) Option {
+	return func(c *Connector) {
+		c.log = logger
+	}
+}
 
-	// AWSRegion is an optional parameter and is regarded only if the parameter AWSProfile is empty.
-	// The AWSRegion has to specify the region in which the data-center to be scaled resides in.
-	AWSRegion string
+// WithAwsProfile sets the aws profile to be used.
+// The profile represents the name of the aws profile that shall be used to access the resources to scale the aws AutoScalingGroup.
+// This parameter is optional. If the profile is NOT set the instance where sokar runs on has to have enough permissions to access the
+// resources (ASG) for scaling (e.g. granted by a AWS Instance Profile). In this case the region parameter has to be specified instead (via WithAwsRegion()).
+func WithAwsProfile(profile string) Option {
+	return func(c *Connector) {
+		c.awsProfile = profile
+	}
+}
 
-	// ASGTagKey is a optional parameter that can be used to define which tag is used to find the AWS ASG that should be scaled/ modified.
-	ASGTagKey string
+// WithAwsRegion sets the aws region in which the resource to be scaled can be found
+func WithAwsRegion(region string) Option {
+	return func(c *Connector) {
+		c.awsRegion = region
+	}
 }
 
 // New creates a new nomad connector
-func (cfg *Config) New() (*Connector, error) {
-
-	cfg.Logger.Info().Msg("Setting up aws Ec2 connector")
-
-	if len(cfg.AWSProfile) == 0 && len(cfg.AWSRegion) == 0 {
-		return nil, fmt.Errorf("The parameters AWSRegion and AWSProfile are empty")
-	}
-
-	if len(cfg.ASGTagKey) == 0 {
-		return nil, fmt.Errorf("The parameter ASGTagKey is empty")
-	}
-
-	nc := &Connector{
-		log:                        cfg.Logger,
-		tagKey:                     cfg.ASGTagKey,
+func New(asgTagKey string, options ...Option) (*Connector, error) {
+	awsEc2Conn := Connector{
+		tagKey:                     asgTagKey,
 		autoScalingFactory:         &aws.AutoScalingFactoryImpl{},
 		fnCreateSession:            aws.NewAWSSession,
 		fnCreateSessionFromProfile: aws.NewAWSSessionFromProfile,
-		awsProfile:                 cfg.AWSProfile,
-		awsRegion:                  cfg.AWSRegion,
 	}
 
-	cfg.Logger.Info().Msg("Setting up aws Ec2 connector ... done")
-	return nc, nil
+	// apply the options
+	for _, opt := range options {
+		opt(&awsEc2Conn)
+	}
+
+	if err := validate(awsEc2Conn); err != nil {
+		return nil, err
+	}
+
+	return &awsEc2Conn, nil
 }
 
 func (c *Connector) String() string {
 	return "AWS-EC2 (AWS AutoScalingGroup, EC2 instances)"
+}
+
+func validate(c Connector) error {
+
+	if len(c.tagKey) == 0 {
+		return fmt.Errorf("the tagkey to identify the AutoScalingGroup that should be scaled is not specified")
+	}
+	if len(c.awsProfile) == 0 && len(c.awsRegion) == 0 {
+		return fmt.Errorf("aws profile and region are not specified")
+	}
+	return nil
 }

--- a/awsEc2/connector.go
+++ b/awsEc2/connector.go
@@ -49,16 +49,6 @@ func WithLogger(logger zerolog.Logger) Option {
 	}
 }
 
-// WithAwsProfile sets the aws profile to be used.
-// The profile represents the name of the aws profile that shall be used to access the resources to scale the aws AutoScalingGroup.
-// This parameter is optional. If the profile is NOT set the instance where sokar runs on has to have enough permissions to access the
-// resources (ASG) for scaling (e.g. granted by a AWS Instance Profile). In this case the region parameter has to be specified instead (via WithAwsRegion()).
-func WithAwsProfile(profile string) Option {
-	return func(c *Connector) {
-		c.awsProfile = profile
-	}
-}
-
 // WithAwsRegion sets the aws region in which the resource to be scaled can be found
 func WithAwsRegion(region string) Option {
 	return func(c *Connector) {
@@ -67,12 +57,16 @@ func WithAwsRegion(region string) Option {
 }
 
 // New creates a new nomad connector
-func New(asgTagKey string, options ...Option) (*Connector, error) {
+// The profile represents the name of the aws profile that shall be used to access the resources to scale the aws AutoScalingGroup.
+// This parameter is optional. If the profile is NOT set the instance where sokar runs on has to have enough permissions to access the
+// resources (ASG) for scaling (e.g. granted by a AWS Instance Profile). In this case the region parameter has to be specified instead (via WithAwsRegion()).
+func New(asgTagKey, awsProfile string, options ...Option) (*Connector, error) {
 	awsEc2Conn := Connector{
 		tagKey:                     asgTagKey,
 		autoScalingFactory:         &aws.AutoScalingFactoryImpl{},
 		fnCreateSession:            aws.NewAWSSession,
 		fnCreateSessionFromProfile: aws.NewAWSSessionFromProfile,
+		awsProfile:                 awsProfile,
 	}
 
 	// apply the options

--- a/awsEc2/connector_test.go
+++ b/awsEc2/connector_test.go
@@ -8,25 +8,40 @@ import (
 
 func TestNewConnector(t *testing.T) {
 
+	// ASGTagKey not specified
+	connector, err := New("")
+	assert.Nil(t, connector)
+	assert.Error(t, err)
+
 	// AWSProfile and AWSRegion not specified
-	cfg := Config{}
-	connector, err := cfg.New()
-
+	connector, err = New("data-center")
 	assert.Nil(t, connector)
 	assert.Error(t, err)
 
-	cfg = Config{AWSProfile: "test", ASGTagKey: "data-center"}
-	connector, err = cfg.New()
+	// success (profile)
+	connector, err = New("data-center", WithAwsProfile("profile"))
 	assert.NotNil(t, connector)
 	assert.NoError(t, err)
+	assert.Equal(t, "profile", connector.awsProfile)
 
-	cfg = Config{AWSRegion: "test-region", ASGTagKey: "data-center"}
-	connector, err = cfg.New()
+	// success (region)
+	connector, err = New("data-center", WithAwsRegion("region"))
 	assert.NotNil(t, connector)
 	assert.NoError(t, err)
+	assert.Equal(t, "region", connector.awsRegion)
+}
 
-	cfg = Config{AWSRegion: "test-region"}
-	connector, err = cfg.New()
-	assert.Nil(t, connector)
+func TestValidate(t *testing.T) {
+
+	// all missing
+	err := validate(Connector{})
 	assert.Error(t, err)
+
+	// region and profile missing
+	err = validate(Connector{tagKey: "tagkey"})
+	assert.Error(t, err)
+
+	// success
+	err = validate(Connector{tagKey: "tagkey", awsProfile: "profile"})
+	assert.NoError(t, err)
 }

--- a/awsEc2/connector_test.go
+++ b/awsEc2/connector_test.go
@@ -9,23 +9,23 @@ import (
 func TestNewConnector(t *testing.T) {
 
 	// ASGTagKey not specified
-	connector, err := New("")
+	connector, err := New("", "profile")
 	assert.Nil(t, connector)
 	assert.Error(t, err)
 
 	// AWSProfile and AWSRegion not specified
-	connector, err = New("data-center")
+	connector, err = New("data-center", "")
 	assert.Nil(t, connector)
 	assert.Error(t, err)
 
 	// success (profile)
-	connector, err = New("data-center", WithAwsProfile("profile"))
+	connector, err = New("data-center", "profile")
 	assert.NotNil(t, connector)
 	assert.NoError(t, err)
 	assert.Equal(t, "profile", connector.awsProfile)
 
 	// success (region)
-	connector, err = New("data-center", WithAwsRegion("region"))
+	connector, err = New("data-center", "", WithAwsRegion("region"))
 	assert.NotNil(t, connector)
 	assert.NoError(t, err)
 	assert.Equal(t, "region", connector.awsRegion)

--- a/awsEc2/ec2_test.go
+++ b/awsEc2/ec2_test.go
@@ -53,7 +53,7 @@ func TestAdjustScalingObjectCount(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	connector, err := New(key, WithAwsProfile("profile"))
+	connector, err := New(key, "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -109,7 +109,7 @@ func TestGetScalingObjectCount(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	connector, err := New(key, WithAwsProfile("profile"))
+	connector, err := New(key, "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -157,7 +157,7 @@ func Test_IsScalingObjectDead(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	connector, err := New(key, WithAwsProfile("profile"))
+	connector, err := New(key, "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 

--- a/awsEc2/ec2_test.go
+++ b/awsEc2/ec2_test.go
@@ -53,8 +53,7 @@ func TestAdjustScalingObjectCount(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	cfg := Config{AWSProfile: "xyz", ASGTagKey: key}
-	connector, err := cfg.New()
+	connector, err := New(key, WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -110,8 +109,7 @@ func TestGetScalingObjectCount(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	cfg := Config{AWSProfile: "xyz", ASGTagKey: key}
-	connector, err := cfg.New()
+	connector, err := New(key, WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -159,8 +157,7 @@ func Test_IsScalingObjectDead(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	cfg := Config{AWSProfile: "xyz", ASGTagKey: key}
-	connector, err := cfg.New()
+	connector, err := New(key, WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 

--- a/capacityPlanner/planConstant_test.go
+++ b/capacityPlanner/planConstant_test.go
@@ -9,11 +9,11 @@ import (
 
 func Test_PlanConstant(t *testing.T) {
 
-	cfg := NewDefaultConfig()
-	cap, err := cfg.New()
+	cap, err := New()
 	require.NotNil(t, cap)
 	require.NoError(t, err)
 
+	// verify default behavior ... constant planning
 	assert.Equal(t, uint(0), cap.planConstant(-1, 0, 1))
 	assert.Equal(t, uint(0), cap.planConstant(-1, 1, 1))
 	assert.Equal(t, uint(0), cap.planConstant(-1, 1, 2))

--- a/capacityPlanner/planLinear_test.go
+++ b/capacityPlanner/planLinear_test.go
@@ -9,10 +9,7 @@ import (
 
 func Test_PlanLinear(t *testing.T) {
 
-	cfg := NewDefaultConfig()
-	cfg.LinearMode = &LinearMode{ScaleFactorWeight: 0.5}
-	cfg.ConstantMode = nil
-	cap, err := cfg.New()
+	cap, err := New(UseLinearMode(0.5))
 	require.NotNil(t, cap)
 	require.NoError(t, err)
 

--- a/config/fillCfg_test.go
+++ b/config/fillCfg_test.go
@@ -317,6 +317,7 @@ func Test_FillCfg_SupportDeprecatedFlags(t *testing.T) {
 	cfg = NewDefaultConfig()
 	args = []string{
 		"--sca.mode=job",
+		"--sca.nomad.server-address=http://1.2.3.4",
 	}
 
 	err = cfg.ReadConfig(args)
@@ -327,9 +328,36 @@ func Test_FillCfg_SupportDeprecatedFlags(t *testing.T) {
 	cfg = NewDefaultConfig()
 	args = []string{
 		"--sca.mode=dc",
+		"--sca.nomad.server-address=http://1.2.3.4",
 	}
 
 	err = cfg.ReadConfig(args)
 	assert.NoError(t, err)
 	assert.Equal(t, ScalerModeNomadDataCenter, cfg.Scaler.Mode)
+}
+
+func Test_ValidateCapacityPlanner(t *testing.T) {
+	capacityPlanner := CapacityPlanner{}
+	err := validateCapacityPlanner(capacityPlanner)
+	assert.Error(t, err)
+
+	capacityPlanner = CapacityPlanner{ConstantMode: CAPConstMode{Enable: true}, LinearMode: CAPLinearMode{Enable: true}}
+	err = validateCapacityPlanner(capacityPlanner)
+	assert.Error(t, err)
+
+	capacityPlanner = CapacityPlanner{LinearMode: CAPLinearMode{Enable: true, ScaleFactorWeight: 0}}
+	err = validateCapacityPlanner(capacityPlanner)
+	assert.Error(t, err)
+
+	capacityPlanner = CapacityPlanner{ConstantMode: CAPConstMode{Enable: true, Offset: 0}}
+	err = validateCapacityPlanner(capacityPlanner)
+	assert.Error(t, err)
+
+	capacityPlanner = CapacityPlanner{LinearMode: CAPLinearMode{Enable: true, ScaleFactorWeight: 0.5}}
+	err = validateCapacityPlanner(capacityPlanner)
+	assert.NoError(t, err)
+
+	capacityPlanner = CapacityPlanner{ConstantMode: CAPConstMode{Enable: true, Offset: 1}}
+	err = validateCapacityPlanner(capacityPlanner)
+	assert.NoError(t, err)
 }

--- a/logging/loggerfactory_test.go
+++ b/logging/loggerfactory_test.go
@@ -10,24 +10,18 @@ import (
 
 func TestNew(t *testing.T) {
 
-	cfg := Config{}
-	lf := cfg.New()
+	lf := New(false, false, false)
 	assert.NotNil(t, lf)
 	assert.NotEmpty(t, zerolog.TimeFieldFormat)
 
-	cfg = Config{
-		UseUnixTimestampForLogging: true,
-	}
-	lf = cfg.New()
+	lf = New(false, true, false)
 	assert.NotNil(t, lf)
 	assert.Empty(t, zerolog.TimeFieldFormat)
 }
 
 func TestNewNamedLogger(t *testing.T) {
 
-	loggerFactory := loggerFactoryImpl{
-		UseStructuredLogging: true,
-	}
+	loggerFactory := New(true, false, false)
 
 	logger := loggerFactory.NewNamedLogger("MyTestLogger")
 	strout := strings.Builder{}
@@ -36,9 +30,7 @@ func TestNewNamedLogger(t *testing.T) {
 	assert.Contains(t, strout.String(), "MyTestLogger")
 	strout.Reset()
 
-	loggerFactory = loggerFactoryImpl{
-		UseStructuredLogging: false,
-	}
+	loggerFactory = New(false, false, false)
 
 	logger = loggerFactory.NewNamedLogger("MyTestLogger2")
 	loggerDup = logger.Output(&strout)
@@ -46,11 +38,9 @@ func TestNewNamedLogger(t *testing.T) {
 	assert.Contains(t, strout.String(), "MyTestLogger2")
 }
 
-func ExampleConfig_New() {
-	cfg := Config{UseStructuredLogging: true}
-
+func ExampleNew() {
 	// create the factory
-	loggingFactory := cfg.New()
+	loggingFactory := New(true, false, false)
 
 	// create new named logger
 	logger := loggingFactory.NewNamedLogger("MyLogger")

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	logger.Info().Msg("Connecting components and setting up sokar")
 
 	logger.Info().Msg("1. Setup: API")
-	api := api.New(cfg.Port, loggingFactory.NewNamedLogger("sokar.api"))
+	api := api.New(cfg.Port, api.WithLogger(loggingFactory.NewNamedLogger("sokar.api")))
 
 	logger.Info().Msg("2. Setup: ScaleAlertEmitters")
 	scaleAlertEmitters := helper.Must(setupScaleAlertEmitters(api, loggingFactory)).([]scaleAlertAggregator.ScaleAlertEmitter)

--- a/main.go
+++ b/main.go
@@ -144,13 +144,8 @@ func setupLogging(cfg *config.Config) (logging.LoggerFactory, error) {
 	if cfg == nil {
 		return nil, fmt.Errorf("Error creating LoggerFactory: Config is nil")
 	}
-	lCfg := logging.Config{
-		UseStructuredLogging:       cfg.Logging.Structured,
-		UseUnixTimestampForLogging: cfg.Logging.UxTimestamp,
-		NoColoredLogOutput:         cfg.Logging.NoColoredLogOutput,
-	}
 
-	loggingFactory := lCfg.New()
+	loggingFactory := logging.New(cfg.Logging.Structured, cfg.Logging.UxTimestamp, cfg.Logging.NoColoredLogOutput)
 	return loggingFactory, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -181,10 +181,7 @@ func setupScaleAlertEmitters(api *api.API, logF logging.LoggerFactory) ([]scaleA
 
 	// Alertmanger Connector
 	logger := logF.NewNamedLogger("sokar.alertmanager")
-	amCfg := alertmanager.Config{
-		Logger: logger,
-	}
-	amConnector := amCfg.New()
+	amConnector := alertmanager.New(alertmanager.WithLogger(logger))
 	api.Router.POST(sokar.PathAlertmanager, amConnector.HandleScaleAlerts)
 	logger.Info().Msgf("Connector for alerts from prometheus/alertmanager setup successfully. Will listen for alerts on %s", sokar.PathAlertmanager)
 

--- a/main.go
+++ b/main.go
@@ -222,8 +222,12 @@ func setupScalingTarget(cfg config.Scaler, logF logging.LoggerFactory) (scaler.S
 	var scalingTarget scaler.ScalingTarget
 
 	if cfg.Mode == config.ScalerModeNomadDataCenter {
-		cfg := nomadWorker.Config{NomadServerAddress: cfg.Nomad.ServerAddr, Logger: logF.NewNamedLogger("sokar.nomadWorker"), AWSRegion: cfg.Nomad.DataCenterAWS.Region, AWSProfile: cfg.Nomad.DataCenterAWS.Profile}
-		nomadWorker, err := cfg.New()
+		nomadWorker, err := nomadWorker.New(
+			cfg.Nomad.ServerAddr,
+			nomadWorker.WithLogger(logF.NewNamedLogger("sokar.nomadWorker")),
+			nomadWorker.WithAwsProfile(cfg.Nomad.DataCenterAWS.Profile),
+			nomadWorker.WithAwsRegion(cfg.Nomad.DataCenterAWS.Region),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("Failed setting up nomad worker connector: %s", err)
 		}

--- a/main.go
+++ b/main.go
@@ -67,22 +67,19 @@ func main() {
 
 	logger.Info().Msg("6. Setup: CapacityPlanner")
 
-	var capaPlanner *capacityPlanner.CapacityPlanner
+	var mode capacityPlanner.Option
 	if cfg.CapacityPlanner.ConstantMode.Enable {
-		capaPlanner = helper.Must(capacityPlanner.New(
-			capacityPlanner.WithLogger(loggingFactory.NewNamedLogger("sokar.capaPlanner")),
-			capacityPlanner.UseConstantMode(cfg.CapacityPlanner.ConstantMode.Offset),
-			capacityPlanner.WithDownScaleCooldown(cfg.CapacityPlanner.DownScaleCooldownPeriod),
-			capacityPlanner.WithUpScaleCooldown(cfg.CapacityPlanner.UpScaleCooldownPeriod),
-		)).(*capacityPlanner.CapacityPlanner)
+		mode = capacityPlanner.UseConstantMode(cfg.CapacityPlanner.ConstantMode.Offset)
 	} else if cfg.CapacityPlanner.LinearMode.Enable {
-		capaPlanner = helper.Must(capacityPlanner.New(
-			capacityPlanner.WithLogger(loggingFactory.NewNamedLogger("sokar.capaPlanner")),
-			capacityPlanner.UseLinearMode(float32(cfg.CapacityPlanner.LinearMode.ScaleFactorWeight)),
-			capacityPlanner.WithDownScaleCooldown(cfg.CapacityPlanner.DownScaleCooldownPeriod),
-			capacityPlanner.WithUpScaleCooldown(cfg.CapacityPlanner.UpScaleCooldownPeriod),
-		)).(*capacityPlanner.CapacityPlanner)
+		mode = capacityPlanner.UseLinearMode(float32(cfg.CapacityPlanner.LinearMode.ScaleFactorWeight))
 	}
+
+	capaPlanner := helper.Must(capacityPlanner.New(
+		capacityPlanner.WithLogger(loggingFactory.NewNamedLogger("sokar.capaPlanner")),
+		capacityPlanner.WithDownScaleCooldown(cfg.CapacityPlanner.DownScaleCooldownPeriod),
+		capacityPlanner.WithUpScaleCooldown(cfg.CapacityPlanner.UpScaleCooldownPeriod),
+		mode,
+	)).(*capacityPlanner.CapacityPlanner)
 
 	logger.Info().Msg("7. Setup: Sokar")
 	sokarInst := helper.Must(setupSokar(scaAlertAggr, capaPlanner, scaler, api, logger, cfg.DryRunMode)).(*sokar.Sokar)

--- a/main.go
+++ b/main.go
@@ -224,8 +224,8 @@ func setupScalingTarget(cfg config.Scaler, logF logging.LoggerFactory) (scaler.S
 	if cfg.Mode == config.ScalerModeNomadDataCenter {
 		nomadWorker, err := nomadWorker.New(
 			cfg.Nomad.ServerAddr,
+			cfg.Nomad.DataCenterAWS.Profile,
 			nomadWorker.WithLogger(logF.NewNamedLogger("sokar.nomadWorker")),
-			nomadWorker.WithAwsProfile(cfg.Nomad.DataCenterAWS.Profile),
 			nomadWorker.WithAwsRegion(cfg.Nomad.DataCenterAWS.Region),
 		)
 		if err != nil {
@@ -235,8 +235,8 @@ func setupScalingTarget(cfg config.Scaler, logF logging.LoggerFactory) (scaler.S
 	} else if cfg.Mode == config.ScalerModeAwsEc2 {
 		awsEc2, err := awsEc2.New(
 			cfg.AwsEc2.ASGTagKey,
+			cfg.AwsEc2.Profile,
 			awsEc2.WithLogger(logF.NewNamedLogger("sokar.aws-ec2")),
-			awsEc2.WithAwsProfile(cfg.AwsEc2.Profile),
 			awsEc2.WithAwsRegion(cfg.AwsEc2.Region),
 		)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -232,8 +232,12 @@ func setupScalingTarget(cfg config.Scaler, logF logging.LoggerFactory) (scaler.S
 		}
 		scalingTarget = nomadWorker
 	} else if cfg.Mode == config.ScalerModeAwsEc2 {
-		cfg := awsEc2.Config{Logger: logF.NewNamedLogger("sokar.aws-ec2"), AWSRegion: cfg.AwsEc2.Region, AWSProfile: cfg.AwsEc2.Profile, ASGTagKey: cfg.AwsEc2.ASGTagKey}
-		awsEc2, err := cfg.New()
+		awsEc2, err := awsEc2.New(
+			cfg.AwsEc2.ASGTagKey,
+			awsEc2.WithLogger(logF.NewNamedLogger("sokar.aws-ec2")),
+			awsEc2.WithAwsProfile(cfg.AwsEc2.Profile),
+			awsEc2.WithAwsRegion(cfg.AwsEc2.Region),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("Failed setting up aws-ec2 connector: %s", err)
 		}

--- a/main.go
+++ b/main.go
@@ -243,9 +243,10 @@ func setupScalingTarget(cfg config.Scaler, logF logging.LoggerFactory) (scaler.S
 		}
 		scalingTarget = awsEc2
 	} else {
-		nomadConfig := nomad.NewDefaultConfig(cfg.Nomad.ServerAddr)
-		nomadConfig.Logger = logF.NewNamedLogger("sokar.nomad")
-		nomad, err := nomadConfig.New()
+		nomad, err := nomad.New(
+			cfg.Nomad.ServerAddr,
+			nomad.WithLogger(logF.NewNamedLogger("sokar.nomad")),
+		)
 		if err != nil {
 			return nil, fmt.Errorf("Failed setting up nomad connector: %s", err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thomasobenaus/sokar/api"
@@ -86,13 +85,12 @@ func Test_SetupScaleEmitters(t *testing.T) {
 	defer mockCtrl.Finish()
 
 	logF := mock_logging.NewMockLoggerFactory(mockCtrl)
-	logger := zerolog.Logger{}
 
 	emitters, err := setupScaleAlertEmitters(nil, nil)
 	assert.Error(t, err)
 	assert.Nil(t, emitters)
 
-	apiInst := api.New(12000, logger)
+	apiInst := api.New(12000)
 	emitters, err = setupScaleAlertEmitters(apiInst, nil)
 	assert.Error(t, err)
 	assert.Nil(t, emitters)

--- a/main_test.go
+++ b/main_test.go
@@ -30,7 +30,7 @@ func Test_CliAndConfig(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, cfg)
 
-	args = []string{"./sokar-bin"}
+	args = []string{"./sokar-bin", "--sca.nomad.server-address=" + nomadSrvAddr}
 	cfg, err = cliAndConfig(args)
 	assert.NoError(t, err)
 	assert.NotNil(t, cfg)

--- a/nomad/connector_test.go
+++ b/nomad/connector_test.go
@@ -3,28 +3,32 @@ package nomad
 import (
 	"log"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewConnector(t *testing.T) {
 
-	cfg := Config{NomadServerAddress: "http://1.2.3.4"}
-	connector, err := cfg.New()
-
+	connector, err := New("http://1.2.3.4")
 	assert.NotNil(t, connector)
 	assert.NoError(t, err)
+	assert.Equal(t, time.Minute, connector.deploymentTimeOut)
+	assert.Equal(t, time.Second*30, connector.evaluationTimeOut)
 
-	cfg = Config{}
-	connector, err = cfg.New()
+	connector, err = New("http://1.2.3.4", WithDeploymentTimeOut(time.Second*1234), WithEvaluationTimeOut(time.Second*5678))
+	assert.NotNil(t, connector)
+	assert.NoError(t, err)
+	assert.Equal(t, time.Second*1234, connector.deploymentTimeOut)
+	assert.Equal(t, time.Second*5678, connector.evaluationTimeOut)
 
+	connector, err = New("")
 	assert.Nil(t, connector)
 	assert.Error(t, err)
 }
 
-func ExampleConfig_New() {
-	cfg := NewDefaultConfig("http://1.2.3.4")
-	conn, err := cfg.New()
+func ExampleNew() {
+	conn, err := New("http://1.2.3.4")
 
 	if err != nil {
 		log.Fatalf("Unable to create connector: %s.", err.Error())

--- a/nomadWorker/connector.go
+++ b/nomadWorker/connector.go
@@ -60,16 +60,6 @@ func WithLogger(logger zerolog.Logger) Option {
 	}
 }
 
-// WithAwsProfile sets the aws profile to be used.
-// The profile represents the name of the aws profile that shall be used to access the resources to scale the aws AutoScalingGroup.
-// This parameter is optional. If the profile is NOT set the instance where sokar runs on has to have enough permissions to access the
-// resources (ASG) for scaling (e.g. granted by a AWS Instance Profile). In this case the region parameter has to be specified instead (via WithAwsRegion()).
-func WithAwsProfile(profile string) Option {
-	return func(c *Connector) {
-		c.awsProfile = profile
-	}
-}
-
 // WithAwsRegion sets the aws region in which the resource to be scaled can be found
 func WithAwsRegion(region string) Option {
 	return func(c *Connector) {
@@ -77,8 +67,11 @@ func WithAwsRegion(region string) Option {
 	}
 }
 
-// New creates a new nomad connector
-func New(nomadServerAddress string, options ...Option) (*Connector, error) {
+// New creates a new nomad worker connector.
+// The profile represents the name of the aws profile that shall be used to access the resources to scale the aws AutoScalingGroup.
+// This parameter is optional. If the profile is NOT set the instance where sokar runs on has to have enough permissions to access the
+// resources (ASG) for scaling (e.g. granted by a AWS Instance Profile). In this case the region parameter has to be specified instead (via WithAwsRegion()).
+func New(nomadServerAddress, awsProfile string, options ...Option) (*Connector, error) {
 	if len(nomadServerAddress) == 0 {
 		return nil, fmt.Errorf("required configuration 'nomadServerAddress' is missing/ empty")
 	}
@@ -90,6 +83,7 @@ func New(nomadServerAddress string, options ...Option) (*Connector, error) {
 		fnCreateSessionFromProfile: aws.NewAWSSessionFromProfile,
 		nodeDrainDeadline:          time.Second * 30,
 		monitorInstanceTimeout:     time.Second * 180,
+		awsProfile:                 awsProfile,
 	}
 
 	// config needed to set up a nomad api client

--- a/nomadWorker/connector_test.go
+++ b/nomadWorker/connector_test.go
@@ -9,21 +9,17 @@ import (
 func TestNewConnector(t *testing.T) {
 
 	// AWSProfile and AWSRegion not specified
-	cfg := Config{}
-	connector, err := cfg.New()
-
+	connector, err := New("")
 	assert.Nil(t, connector)
 	assert.Error(t, err)
 
 	// NomadSrvAddr missing
-	cfg = Config{AWSProfile: "test"}
-	connector, err = cfg.New()
+	connector, err = New("")
 	assert.Nil(t, connector)
 	assert.Error(t, err)
 
 	// Success
-	cfg = Config{AWSProfile: "test", NomadServerAddress: "http://nomad.io"}
-	connector, err = cfg.New()
+	connector, err = New("http://nomad.io", WithAwsProfile("profile"))
 	assert.NotNil(t, connector)
 	assert.NoError(t, err)
 }

--- a/nomadWorker/connector_test.go
+++ b/nomadWorker/connector_test.go
@@ -9,17 +9,17 @@ import (
 func TestNewConnector(t *testing.T) {
 
 	// AWSProfile and AWSRegion not specified
-	connector, err := New("")
+	connector, err := New("http://nomad.io", "")
 	assert.Nil(t, connector)
 	assert.Error(t, err)
 
 	// NomadSrvAddr missing
-	connector, err = New("")
+	connector, err = New("", "profile")
 	assert.Nil(t, connector)
 	assert.Error(t, err)
 
 	// Success
-	connector, err = New("http://nomad.io", WithAwsProfile("profile"))
+	connector, err = New("http://nomad.io", "profile")
 	assert.NotNil(t, connector)
 	assert.NoError(t, err)
 }

--- a/nomadWorker/downscale_test.go
+++ b/nomadWorker/downscale_test.go
@@ -114,8 +114,7 @@ func Test_Downscale(t *testing.T) {
 	nodesIF := mock_nomadWorker.NewMockNodes(mockCtrl)
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
-	cfg := Config{AWSProfile: "xyz", NomadServerAddress: "http://nomad.io"}
-	connector, err := cfg.New()
+	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 

--- a/nomadWorker/downscale_test.go
+++ b/nomadWorker/downscale_test.go
@@ -114,7 +114,7 @@ func Test_Downscale(t *testing.T) {
 	nodesIF := mock_nomadWorker.NewMockNodes(mockCtrl)
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
-	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
+	connector, err := New("http://nomad.io", "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 

--- a/nomadWorker/ec2_test.go
+++ b/nomadWorker/ec2_test.go
@@ -52,7 +52,7 @@ func TestAdjustScalingObjectCount_Error(t *testing.T) {
 	asgFactory := mock_aws.NewMockAutoScalingFactory(mockCtrl)
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
-	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
+	connector, err := New("http://nomad.io", "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -73,7 +73,7 @@ func TestAdjustScalingObjectCount_Upscale(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
+	connector, err := New("http://nomad.io", "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -114,7 +114,7 @@ func TestAdjustScalingObjectCount_NoScale(t *testing.T) {
 	asgFactory := mock_aws.NewMockAutoScalingFactory(mockCtrl)
 
 	key := "datacenter"
-	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
+	connector, err := New("http://nomad.io", "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -150,7 +150,7 @@ func TestGetScalingObjectCount(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
+	connector, err := New("http://nomad.io", "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -198,7 +198,7 @@ func Test_IsScalingObjectDead(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
+	connector, err := New("http://nomad.io", "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -247,7 +247,7 @@ func TestAdjustScalingObjectCount_Downscale(t *testing.T) {
 	asgFactory := mock_aws.NewMockAutoScalingFactory(mockCtrl)
 
 	key := "datacenter"
-	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
+	connector, err := New("http://nomad.io", "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 

--- a/nomadWorker/ec2_test.go
+++ b/nomadWorker/ec2_test.go
@@ -52,8 +52,7 @@ func TestAdjustScalingObjectCount_Error(t *testing.T) {
 	asgFactory := mock_aws.NewMockAutoScalingFactory(mockCtrl)
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
-	cfg := Config{AWSProfile: "xyz", NomadServerAddress: "http://nomad.io"}
-	connector, err := cfg.New()
+	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -74,8 +73,7 @@ func TestAdjustScalingObjectCount_Upscale(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	cfg := Config{AWSProfile: "xyz", NomadServerAddress: "http://nomad.io"}
-	connector, err := cfg.New()
+	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -116,8 +114,7 @@ func TestAdjustScalingObjectCount_NoScale(t *testing.T) {
 	asgFactory := mock_aws.NewMockAutoScalingFactory(mockCtrl)
 
 	key := "datacenter"
-	cfg := Config{AWSProfile: "xyz", NomadServerAddress: "http://nomad.io"}
-	connector, err := cfg.New()
+	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -153,8 +150,7 @@ func TestGetScalingObjectCount(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	cfg := Config{AWSProfile: "xyz", NomadServerAddress: "http://nomad.io"}
-	connector, err := cfg.New()
+	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -202,8 +198,7 @@ func Test_IsScalingObjectDead(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	cfg := Config{AWSProfile: "xyz", NomadServerAddress: "http://nomad.io"}
-	connector, err := cfg.New()
+	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 
@@ -252,8 +247,7 @@ func TestAdjustScalingObjectCount_Downscale(t *testing.T) {
 	asgFactory := mock_aws.NewMockAutoScalingFactory(mockCtrl)
 
 	key := "datacenter"
-	cfg := Config{AWSProfile: "xyz", NomadServerAddress: "http://nomad.io"}
-	connector, err := cfg.New()
+	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 

--- a/nomadWorker/upscale_test.go
+++ b/nomadWorker/upscale_test.go
@@ -18,8 +18,7 @@ func TestUpscale(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	cfg := Config{AWSProfile: "xyz", NomadServerAddress: "http://nomad.io"}
-	connector, err := cfg.New()
+	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 

--- a/nomadWorker/upscale_test.go
+++ b/nomadWorker/upscale_test.go
@@ -18,7 +18,7 @@ func TestUpscale(t *testing.T) {
 	asgIF := mock_aws.NewMockAutoScaling(mockCtrl)
 
 	key := "datacenter"
-	connector, err := New("http://nomad.io", WithAwsProfile("profile"))
+	connector, err := New("http://nomad.io", "profile")
 	require.NotNil(t, connector)
 	require.NoError(t, err)
 

--- a/runnable.go
+++ b/runnable.go
@@ -10,7 +10,7 @@ import (
 type Runnable interface {
 	Run()
 	Join()
-	Stop()
+	Stop() error
 	GetName() string
 }
 
@@ -40,7 +40,11 @@ func Stop(orderedRunnables []Runnable, logger zerolog.Logger) {
 		runnable := orderedRunnables[i]
 		name := runnable.GetName()
 		logger.Debug().Msgf("Stopping %s ...", name)
-		runnable.Stop()
+		err := runnable.Stop()
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed stopping '%s'")
+			continue
+		}
 		logger.Info().Msgf("%s stopped.", name)
 	}
 }

--- a/scaleAlertAggregator/scaleAlertAggregatorImpl.go
+++ b/scaleAlertAggregator/scaleAlertAggregatorImpl.go
@@ -98,10 +98,12 @@ func updateAlertMetrics(pool *ScaleAlertPool, metrics *Metrics) {
 }
 
 // Stop tears down ScaleAlertAggregator
-func (sc *ScaleAlertAggregator) Stop() {
+func (sc *ScaleAlertAggregator) Stop() error {
 	sc.logger.Info().Msg("Teardown requested")
 	// send the stop message
 	sc.stopChan <- struct{}{}
+
+	return nil
 }
 
 // Join blocks/ waits until ScaleAlertAggregator has been stopped

--- a/scaler/scaler.go
+++ b/scaler/scaler.go
@@ -119,11 +119,13 @@ func (s *Scaler) Run() {
 }
 
 // Stop tears down scaler
-func (s *Scaler) Stop() {
+func (s *Scaler) Stop() error {
 	s.logger.Info().Msg("Teardown requested")
 
 	close(s.scaleTicketChan)
 	close(s.stopChan)
+
+	return nil
 }
 
 // Join blocks/ waits until scaler has been stopped

--- a/sokar/scaleBy.go
+++ b/sokar/scaleBy.go
@@ -18,11 +18,13 @@ func (sk *Sokar) ScaleByPercentage(w http.ResponseWriter, r *http.Request, ps ht
 	sk.logger.Info().Msgf("ScaleBy Percentage Endpoint with '%s %%' called.", percentageStr)
 	percentage, err := strconv.ParseInt(percentageStr, 10, 64)
 	if err != nil {
+		sk.logger.Error().Err(err).Msg("Percentage parameter is invalid.")
 		http.Error(w, fmt.Sprintf("Percentage parameter is invalid: %s", err.Error()), http.StatusBadRequest)
 		return
 	}
 
 	if !sk.dryRunMode {
+		sk.logger.Error().Msg("The scale by endpoint is only supported if sokar is running in dry-run mode.")
 		http.Error(w, "The scale by endpoint is only supported if sokar is running in dry-run mode.", http.StatusBadRequest)
 		return
 	}
@@ -30,6 +32,7 @@ func (sk *Sokar) ScaleByPercentage(w http.ResponseWriter, r *http.Request, ps ht
 	percentageFract := float32(percentage) / 100.00
 	err = sk.triggerScale(false, percentageFract, planScaleByPercentage)
 	if err != nil {
+		sk.logger.Error().Err(err).Msg("Unable to trigger scale")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -46,17 +49,20 @@ func (sk *Sokar) ScaleByValue(w http.ResponseWriter, r *http.Request, ps httprou
 	sk.logger.Info().Msgf("ScaleBy Value Endpoint with '%s %%' called.", valueStr)
 	value, err := strconv.ParseInt(valueStr, 10, 64)
 	if err != nil {
+		sk.logger.Error().Err(err).Msg("Percentage parameter is invalid.")
 		http.Error(w, fmt.Sprintf("Value parameter is invalid: %s", err.Error()), http.StatusBadRequest)
 		return
 	}
 
 	if !sk.dryRunMode {
+		sk.logger.Error().Msg("The scale by endpoint is only supported if sokar is running in dry-run mode.")
 		http.Error(w, "The scale by endpoint is only supported if sokar is running in dry-run mode.", http.StatusBadRequest)
 		return
 	}
 
 	err = sk.triggerScale(false, float32(value), planScaleByValue)
 	if err != nil {
+		sk.logger.Error().Err(err).Msg("Unable to trigger scale")
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/sokar/sokar.go
+++ b/sokar/sokar.go
@@ -77,9 +77,10 @@ func (cfg *Config) New(scaleEventEmitter sokarIF.ScaleEventEmitter, capacityPlan
 }
 
 // Stop tears down sokar
-func (sk *Sokar) Stop() {
+func (sk *Sokar) Stop() error {
 	sk.logger.Info().Msg("Teardown requested")
 	close(sk.stopChan)
+	return nil
 }
 
 // Join blocks/ waits until sokar has been stopped

--- a/test/mock_runnable.go
+++ b/test/mock_runnable.go
@@ -53,8 +53,10 @@ func (mr *MockRunnableMockRecorder) Join() *gomock.Call {
 }
 
 // Stop mocks base method
-func (m *MockRunnable) Stop() {
-	m.ctrl.Call(m, "Stop")
+func (m *MockRunnable) Stop() error {
+	ret := m.ctrl.Call(m, "Stop")
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Stop indicates an expected call of Stop


### PR DESCRIPTION
With this PR the massive usage of the anti pattern "config-struct" was reduced.
Where needed the approach of [functional options](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis) was used instead.

This solves #95.