### PR TITLE
Upgrade go + alpine

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,6 +1,6 @@
 
 ## The Build Image
-FROM golang:1.11.5-alpine AS golang
+FROM golang:1.13.1-alpine AS golang
 
 ARG PROJECT_PATH=github.com/thomasobenaus/sokar
 ARG BINARY_NAME=sokar

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -29,7 +29,7 @@ RUN make tools test
 RUN make build build_destination=/work name=${BINARY_NAME}
 
 ## The Run Image
-FROM alpine:3.9
+FROM alpine:3.10
 LABEL maintainer="Thomas Obenaus"
 
 ARG PROJECT_PATH=github.com/thomasobenaus/sokar

--- a/test/service_test/test.Dockerfile
+++ b/test/service_test/test.Dockerfile
@@ -1,5 +1,5 @@
 ## The Build Image
-FROM golang:1.11.5-alpine AS golang
+FROM golang:1.13.1-alpine AS golang
 
 ARG PROJECT_PATH=github.com/thomasobenaus/sokar/test/service_test
 


### PR DESCRIPTION
With this PR go is upgraded from 1.11.5 to 1.13.1 and alpine is upgraded from 3.9 to 3.10